### PR TITLE
PRブランチにpushされたとき、デプロイできるようにする

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: check-code
-    if: contains(github.event_name, 'push')
     permissions:
       id-token: write
       contents: read
@@ -61,4 +60,9 @@ jobs:
           path: ~/.local/share/virtualenvs
           key: ${{ runner.os }}-pipenv-${{ hashFiles('./Pipfile.lock') }}
       - run: make init
-      - run: make deploy
+      - name: Deploy for PR
+        run: sls deploy --stage pr$(jq --raw-output .number "$GITHUB_EVENT_PATH")
+        if: contains(github.event_name, 'pull_request')
+      - name: Deploy for main
+        run: make deploy
+        if: contains(github.event_name, 'push')

--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -1,0 +1,31 @@
+name: CI/CD Pull Request Close
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  remove-pr-app:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ap-northeast-1
+      - uses: actions/setup-python@v3
+        with:
+          python-version: "3.9.11"
+      - uses: actions/setup-node@v2
+      - run: npm install -g serverless@3.12.0
+      - uses: actions/checkout@v2.4.0
+      - run: pip install pipenv
+      - uses: actions/cache@v3.0.1
+        with:
+          path: ~/.local/share/virtualenvs
+          key: ${{ runner.os }}-pipenv-${{ hashFiles('./Pipfile.lock') }}
+      - run: make init
+      - name: Remove PR App
+        run: sls remove --stage pr$(jq --raw-output .number "$GITHUB_EVENT_PATH")


### PR DESCRIPTION
for #18

PRごとに https://2xvtt3tsih.execute-api.us-east-1.amazonaws.com/pr20/slack/events のようなURLが発行されるので、それを任意のSlackアプリに設定して、動作確認することができます。PRがマージされると、そのURLのアプリは削除されます。(= URLにアクセスできなくなります)

URLの確認には、GitHub Actionsのログを参照してください。

<img width="1622" alt="スクリーンショット 2022-04-11 17 02 14" src="https://user-images.githubusercontent.com/48438462/162692222-696d04b2-2ae6-42c0-9fd8-77760927631e.png">

https://github.com/esminc/boat-bee/runs/5968350157?check_suite_focus=true より

発行されたURLをPRにコメントしたいのですが、このPRでは未対応とします。

参考 : [GitHub Actionsを使ってServerless Frameworkチーム開発効率化](https://qiita.com/series7/items/1b77ff6e7f6f5304fea7)