### PR TITLE
regionをap-northeast-1に変更

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,8 +6,7 @@
   ],
   "containerEnv": {
     "AWS_ACCESS_KEY_ID": "${localEnv:AWS_ACCESS_KEY_ID}",
-    "AWS_SECRET_ACCESS_KEY": "${localEnv:AWS_SECRET_ACCESS_KEY}",
-    "AWS_DEFAULT_REGION": "${localEnv:AWS_DEFAULT_REGION}"
+    "AWS_SECRET_ACCESS_KEY": "${localEnv:AWS_SECRET_ACCESS_KEY}"
   },
   "postCreateCommand": "make init",
   "settings": {

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@
 
 - AWS_ACCESS_KEY_ID
 - AWS_SECRET_ACCESS_KEY
-- AWS_DEFAULT_REGION
 
 詳しくは、https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html を参照してください。
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -4,6 +4,7 @@ frameworkVersion: "3"
 
 provider:
   name: aws
+  region: ap-northeast-1
   ecr:
     images:
       appimage:


### PR DESCRIPTION
現時点で、serverlessは環境変数AWS_DEFAULT_REGIONはサポートしていないようなので、serverless.ymlで設定します。

参考 : https://github.com/serverless/serverless/issues/2151

動作確認する場合、一度環境を削除して、デプロイし直す必要があります。