### PR TITLE
各メンバ用のデプロイ環境を作成

### DIFF
--- a/.github/workflows/deploy-stg-a.yml
+++ b/.github/workflows/deploy-stg-a.yml
@@ -1,0 +1,29 @@
+name: Manual Deploy to stage A
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy-stg-a:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ap-northeast-1
+      - uses: actions/setup-python@v3
+        with:
+          python-version: "3.9.11"
+      - uses: actions/setup-node@v2
+      - run: npm install -g serverless@3.12.0
+      - uses: actions/checkout@v2.4.0
+      - run: pip install pipenv
+      - uses: actions/cache@v3.0.1
+        with:
+          path: ~/.local/share/virtualenvs
+          key: ${{ runner.os }}-pipenv-${{ hashFiles('./Pipfile.lock') }}
+      - run: make init
+      - run: sls deploy --stage stage-a

--- a/.github/workflows/deploy-stg-b.yml
+++ b/.github/workflows/deploy-stg-b.yml
@@ -1,0 +1,29 @@
+name: Manual Deploy to stage B
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy-stg-b:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ap-northeast-1
+      - uses: actions/setup-python@v3
+        with:
+          python-version: "3.9.11"
+      - uses: actions/setup-node@v2
+      - run: npm install -g serverless@3.12.0
+      - uses: actions/checkout@v2.4.0
+      - run: pip install pipenv
+      - uses: actions/cache@v3.0.1
+        with:
+          path: ~/.local/share/virtualenvs
+          key: ${{ runner.os }}-pipenv-${{ hashFiles('./Pipfile.lock') }}
+      - run: make init
+      - run: sls deploy --stage stage-b

--- a/.github/workflows/deploy-stg-c.yml
+++ b/.github/workflows/deploy-stg-c.yml
@@ -1,0 +1,29 @@
+name: Manual Deploy to stage C
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy-stg-c:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ap-northeast-1
+      - uses: actions/setup-python@v3
+        with:
+          python-version: "3.9.11"
+      - uses: actions/setup-node@v2
+      - run: npm install -g serverless@3.12.0
+      - uses: actions/checkout@v2.4.0
+      - run: pip install pipenv
+      - uses: actions/cache@v3.0.1
+        with:
+          path: ~/.local/share/virtualenvs
+          key: ${{ runner.os }}-pipenv-${{ hashFiles('./Pipfile.lock') }}
+      - run: make init
+      - run: sls deploy --stage stage-c

--- a/.github/workflows/deploy-stg-d.yml
+++ b/.github/workflows/deploy-stg-d.yml
@@ -1,0 +1,29 @@
+name: Manual Deploy to stage D
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy-stg-d:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ap-northeast-1
+      - uses: actions/setup-python@v3
+        with:
+          python-version: "3.9.11"
+      - uses: actions/setup-node@v2
+      - run: npm install -g serverless@3.12.0
+      - uses: actions/checkout@v2.4.0
+      - run: pip install pipenv
+      - uses: actions/cache@v3.0.1
+        with:
+          path: ~/.local/share/virtualenvs
+          key: ${{ runner.os }}-pipenv-${{ hashFiles('./Pipfile.lock') }}
+      - run: make init
+      - run: sls deploy --stage stage-d

--- a/app.py
+++ b/app.py
@@ -1,19 +1,14 @@
-import json
 import logging
-import os
 
 import awsgi  # type: ignore
-import boto3  # type: ignore
 
 logging.basicConfig(level=logging.DEBUG)
 
-secretsmanager_client = boto3.client("secretsmanager", region_name="us-east-1")
-secret_value = secretsmanager_client.get_secret_value(SecretId="slack_secret")
-secret = json.loads(secret_value["SecretString"])
+from bee_slack_app.env import (  # pylint: disable=wrong-import-position
+    configure_env_values,
+)
 
-os.environ["SLACK_APP_TOKEN"] = secret["SLACK_APP_TOKEN"]
-os.environ["SLACK_BOT_TOKEN"] = secret["SLACK_BOT_TOKEN"]
-os.environ["SLACK_SIGNING_SECRET"] = secret["SLACK_SIGNING_SECRET"]
+configure_env_values()
 
 from bee_slack_app.flask_app import flask_app  # pylint: disable=wrong-import-position
 

--- a/bee_slack_app/env.py
+++ b/bee_slack_app/env.py
@@ -1,0 +1,26 @@
+import json
+import os
+
+import boto3  # type: ignore
+
+
+def configure_env_values():
+
+    secretsmanager_client = boto3.client("secretsmanager", region_name="us-east-1")
+
+    stage = os.environ["SERVERLESS_STAGE"]
+
+    secret_id = None
+    if stage == "dev":
+        secret_id = "slack_secret"
+    elif stage in ["stage-a", "stage-b", "stage-c", "stage-d"]:
+        secret_id = f"slack_secret_{stage}"
+    else:
+        secret_id = "slack_secret"
+
+    secret_value = secretsmanager_client.get_secret_value(SecretId=secret_id)
+    secret = json.loads(secret_value["SecretString"])
+
+    os.environ["SLACK_APP_TOKEN"] = secret["SLACK_APP_TOKEN"]
+    os.environ["SLACK_BOT_TOKEN"] = secret["SLACK_BOT_TOKEN"]
+    os.environ["SLACK_SIGNING_SECRET"] = secret["SLACK_SIGNING_SECRET"]

--- a/serverless.yml
+++ b/serverless.yml
@@ -9,6 +9,7 @@ provider:
       appimage:
         path: ./
   environment:
+    SERVERLESS_STAGE: ${sls:stage}
     DYNAMODB_TABLE: ${self:service}-${sls:stage}
   iamRoleStatements:
     - Effect: Allow


### PR DESCRIPTION
for https://github.com/esminc/boat-bee/issues/18#issuecomment-1094775419

検証用デプロイ環境A~Dを作成しました。

## デプロイ方法

下記の設定により、GitHub Actionsを手動で起動するとコードをデプロイできます。

```yml
on:
  workflow_dispatch:
```

ただし、このPRマージ後から、有効になります。
有効になった後は、mainブランチ以外も、指定してデプロイすることができます。

## Slackアプリのシークレット登録

各デプロイ環境をSlackアプリと連携させるには、下記3つを AWS Secrets Manager に登録する必要があります。

- SLACK_APP_TOKEN
- SLACK_BOT_TOKEN
- SLACK_SIGNING_SECRET

キー名は slack_secret_stage-a のようになります。