### PR TITLE
mainブランチにpushされたときのデプロイが完了したら、Slackに通知する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,22 @@ jobs:
           key: ${{ runner.os }}-pipenv-${{ hashFiles('./Pipfile.lock') }}
       - run: make init
       - run: make deploy
+      - name: Notify Action Result to Slack
+        uses: slackapi/slack-github-action@v1.18.0
+        with:
+          payload: |
+            {
+              "text": "GitHub Action deploy result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "GitHub Action build result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.PR_MESSAGE_SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
close #22 

デプロイが完了したら、成功/失敗のどちらでもSlackに通知します。

Slack公式のaction https://github.com/slackapi/slack-github-action を使っています。
ここでは対応しませんが、 8398a7/action-slack を使っている部分も、後々 slackapi/slack-github-action に置き換えたいと考えています。