### PR TITLE
SlackアプリクレデンシャルのSecretIdの命名規則を修正

### DIFF
--- a/bee_slack_app/env.py
+++ b/bee_slack_app/env.py
@@ -8,15 +8,7 @@ def configure_env_values():
 
     secretsmanager_client = boto3.client("secretsmanager", region_name="us-east-1")
 
-    stage = os.environ["SERVERLESS_STAGE"]
-
-    secret_id = None
-    if stage == "dev":
-        secret_id = "slack_secret"
-    elif stage in ["stage-a", "stage-b", "stage-c", "stage-d"]:
-        secret_id = f"slack_secret_{stage}"
-    else:
-        secret_id = "slack_secret"
+    secret_id = os.environ["SLACK_CREDENTIALS_SECRET_ID"]
 
     secret_value = secretsmanager_client.get_secret_value(SecretId=secret_id)
     secret = json.loads(secret_value["SecretString"])

--- a/serverless.yml
+++ b/serverless.yml
@@ -9,7 +9,7 @@ provider:
       appimage:
         path: ./
   environment:
-    SERVERLESS_STAGE: ${sls:stage}
+    SLACK_CREDENTIALS_SECRET_ID: slack_secret_${sls:stage}
     DYNAMODB_TABLE: ${self:service}-${sls:stage}
   iamRoleStatements:
     - Effect: Allow


### PR DESCRIPTION
今後、第１弾リリースで本番環境を作成するにあたり、新しくシークレットを作成することになると思います。
それを見据えて、`slack_secret_<ステージ名> `としたいです。（コードを変えずに`slack_secret_prod`のように参照したい）

devは、slack_secretからslack_secret_devに変更になります。（Secrets Managerのコンソールで対応済み）
stage-a ~ dは、変更がありません。

