### PR TITLE
推論のタイミングでTensorFlowをimportする

### DIFF
--- a/bee_slack_app/ml.py
+++ b/bee_slack_app/ml.py
@@ -1,7 +1,5 @@
-import tensorflow as tf  # type: ignore
-
-
 def predict():
+    import tensorflow as tf  # type: ignore # pylint: disable=import-outside-toplevel
 
     model = tf.keras.models.load_model("./models/sample")
 


### PR DESCRIPTION
for #40

TensorFlowのimportは無視できない程度、時間がかかります。
現状のトップレベルのimportではLambdaのスタート毎にimportされ、アプリ全体が遅くなる原因になっています。

TensorFlowのimportのタイミングを遅らせることで、これを解消したいです。

もちろん推論のタイミングでのimportでは依然として遅い処理が存在することになります。
こちらは、Lazy リスナーによる非同期処理で対処できるのでは https://github.com/esminc/boat-bee/issues/40#issuecomment-1119181554 と考えています。