### PR TITLE
Slackへの通知にSlack公式Actionを使う

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,14 +28,24 @@ jobs:
       - run: make type-check
       - run: make test
       - name: Notify Action Failure to Slack
-        uses: 8398a7/action-slack@v3.8.0
+        uses: slackapi/slack-github-action@v1.18.0
         with:
-          text: ${{ github.event.pull_request.html_url }} # push to mainイベントのときは空
-          author_name: GitHub Actions 失敗通知
-          status: ${{ job.status }}
-          fields:
+          payload: |
+            {
+              "text": "GitHub Actions 失敗通知 \n${{ github.event.pull_request.html_url || github.event.head_commit.url }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "GitHub Actions 失敗通知 \n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+                  }
+                }
+              ]
+            }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.PR_MESSAGE_SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
         if: failure()
 
   deploy:


### PR DESCRIPTION
from https://github.com/esminc/boat-bee/pull/28#issue-1200868943

> ここでは対応しませんが、 8398a7/action-slack を使っている部分も、後々 slackapi/slack-github-action に置き換えたいと考えています。

上記への対応です。