### PR TITLE
暫定対処：送信時にすべてのモーダルを閉じる

### DIFF
--- a/bee_slack_app/view_controller/review.py
+++ b/bee_slack_app/view_controller/review.py
@@ -44,7 +44,9 @@ def review_controller(app):
             ack(response_action="errors", errors=errors)
             return
         # view_submission リクエストの確認を行い、モーダルを閉じる
-        ack()
+        # この時、最初に開いていたモーダルも含めてすべて閉じるために
+        # response_action="clear" を設定する
+        ack(response_action="clear")
 
         review_contents: ReviewContents = {
             "user_id": user_id,


### PR DESCRIPTION
#127 が時間不足で根本対処ができなかったので第一弾リリースでは仮対処だけして出したいです。


今の動き

- レビュー投稿時の「送信」ボタンですべてのモーダルを閉じる
- この時、裏に残っている親のモーダルも同時に閉じられるので、見た目は期待通り

イマイチなところ

- レビュー投稿時の「閉じる」ボタンを押してモーダルを閉じると、親のモーダルが残っている
- 検索→選択＆決定→検索→選択＆決定→検索→選択＆決定→ を繰り返すと三度目で500エラーになる
不要なモーダルが残っていき、MAXの3に到達しているのが原因