### PR TITLE
slackユーザのdisplay_nameが存在しない場合、「プロフィール」を押下するとエラーになるバグを修正

### DIFF
--- a/bee_slack_app/view_controller/user.py
+++ b/bee_slack_app/view_controller/user.py
@@ -17,7 +17,10 @@ def user_controller(app):
         # slackアカウントから名前（Display Name）Display Nameを取得する
         # display_nameを設定していない場合は、設定必須のreal_nameをユーザ名とすることで、対応する
         user_info = client.users_info(user=user_id)
-        user_name = user_info["user"]["profile"]["display_name"] or user_info["user"]["profile"]["real_name"]
+        user_name = (
+            user_info["user"]["profile"]["display_name"]
+            or user_info["user"]["profile"]["real_name"]
+        )
 
         modal_view = generate_user_input_modal_view(user_name, user)
 


### PR DESCRIPTION
close #204 

display_name（表示名）は設定必須ではないので、設定していない人もいる
設定していない場合、display_nameが空文字になるので、blocksの組み立てでエラーとなる
設定していない場合は、display_nameではなく、設定必須のreal_name（氏名）をbeeのユーザ名とすることで、対応する