### PR TITLE
ReviewRepositoryでレビューコメントが存在しない場合、空文字で返却するように修正

### DIFF
--- a/bee_slack_app/repository/book_review.py
+++ b/bee_slack_app/repository/book_review.py
@@ -38,12 +38,20 @@ class BookReview:
         Returns:
             本のレビュー。存在しない場合はNone。
         """
-        return self.table.get_item(
+        item = self.table.get_item(
             Key={
                 "user_id": user_id,
                 "isbn": isbn,
             }
         ).get("Item")
+
+        if not item:
+            return None
+
+        # item["review_comment"]がNoneの場合、空文字に置き換える
+        item["review_comment"] = item["review_comment"] or ""
+
+        return item
 
     def get_some(
         self,
@@ -99,6 +107,10 @@ class BookReview:
             while last_key is not None:
                 new_items, last_key = scan(exclusive_start_key=last_key)
                 items.extend(new_items)
+
+        for item in items:
+            # item["review_comment"]がNoneの場合、空文字に置き換える
+            item["review_comment"] = item["review_comment"] or ""
 
         return {"items": items, "last_key": last_key}
 

--- a/bee_slack_app/repository/test_book_review.py
+++ b/bee_slack_app/repository/test_book_review.py
@@ -139,6 +139,45 @@ class TestBookReview:
 
         assert review is None
 
+    def test_getでレビューコメントが存在しない場合_レビューコメントは空文字で取得できること(self):
+        item = {
+            "user_id": "user_id_0",
+            "book_title": "仕事ではじめる機械学習",
+            "isbn": "12345",
+            "score_for_me": "1",
+            "score_for_others": "5",
+            "review_comment": None,
+            "updated_at": "2022-04-01T00:00:00+09:00",
+            "book_image_url": "dummy_book_image_url_0",
+            "book_author": "dummy_book_author_0",
+            "book_url": "dummy_book_url_0",
+        }
+
+        self.table.put_item(Item=item)
+
+        item = {
+            "user_id": "user_id_1",
+            "book_title": "仕事ではじめる機械学習",
+            "isbn": "12345",
+            "score_for_me": "3",
+            "score_for_others": "4",
+            "review_comment": "まあまあです",
+            "updated_at": "2022-04-01T00:00:00+09:00",
+            "book_image_url": "dummy_book_image_url_1",
+            "book_author": "dummy_book_author_1",
+            "book_url": "dummy_book_url_1",
+        }
+
+        self.table.put_item(Item=item)
+
+        book_review = BookReview()
+
+        review = book_review.get(user_id="user_id_0", isbn="12345")
+
+        assert review["user_id"] == "user_id_0"
+        assert review["isbn"] == "12345"
+        assert review["review_comment"] == ""
+
     def test_ページネーションして_レビューを取得できること(self):
         item = {
             "user_id": "user_id_0",
@@ -326,6 +365,51 @@ class TestBookReview:
 
         assert len(reviews) == 0
         assert isinstance(reviews, list)
+
+    def test_get_someでレビューコメントが存在しない場合_レビューコメントは空文字で取得できること(self):
+        item = {
+            "user_id": "user_id_0",
+            "book_title": "仕事ではじめる機械学習",
+            "isbn": "12345",
+            "score_for_me": "1",
+            "score_for_others": "5",
+            "review_comment": None,
+            "updated_at": "2022-04-01T00:00:00+09:00",
+            "book_image_url": "dummy_book_image_url_0",
+            "book_author": "dummy_book_author_0",
+            "book_url": "dummy_book_url_0",
+        }
+
+        self.table.put_item(Item=item)
+
+        item = {
+            "user_id": "user_id_1",
+            "book_title": "仕事ではじめる機械学習",
+            "isbn": "12345",
+            "score_for_me": "3",
+            "score_for_others": "4",
+            "review_comment": "まあまあです",
+            "updated_at": "2022-04-01T00:00:00+09:00",
+            "book_image_url": "dummy_book_image_url_1",
+            "book_author": "dummy_book_author_1",
+            "book_url": "dummy_book_url_1",
+        }
+
+        self.table.put_item(Item=item)
+
+        book_review = BookReview()
+
+        reviews = book_review.get_some()["items"]
+
+        assert len(reviews) == 2
+
+        assert reviews[0]["user_id"] == "user_id_0"
+        assert reviews[0]["isbn"] == "12345"
+        assert reviews[0]["review_comment"] == ""
+
+        assert reviews[1]["user_id"] == "user_id_1"
+        assert reviews[1]["isbn"] == "12345"
+        assert reviews[1]["review_comment"] == "まあまあです"
 
     def test_レビューを作成できること(self):
         response = self.table.query(

--- a/bee_slack_app/view/read_review.py
+++ b/bee_slack_app/view/read_review.py
@@ -27,13 +27,7 @@ def review_list_modal(
     for review_contents in review_contents_list:
 
         # 空はエラーになるため、ハイフンを設定
-        # TODO: 本来 review_comment が None になることは想定されていない（get_reviewsが返す型と不一致）なので、service側での修正が必要
-        review_comment = review_contents["review_comment"]
-        review_comment = (
-            review_comment
-            if review_comment is not None and len(review_comment) > 0
-            else "-"
-        )
+        review_comment = review_contents["review_comment"] or "-"
 
         review_list.append(
             {


### PR DESCRIPTION
ReviewContents型ではreview_comment: strとなっていたが、存在しない場合、Noneを返していて、型アノテーションと不一致だった