### PR TITLE
pylintのduplicate-codeをリポジトリ全体で無効化

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,7 +26,7 @@
       */
     "python.linting.pylintArgs": [
       "--disable",
-      "missing-module-docstring, missing-class-docstring, missing-function-docstring, line-too-long, fixme"
+      "missing-module-docstring, missing-class-docstring, missing-function-docstring, line-too-long, fixme, duplicate-code"
     ]
   },
   "extensions": [

--- a/bee_slack_app/service/review.py
+++ b/bee_slack_app/service/review.py
@@ -17,7 +17,7 @@ class ReviewItemKey(TypedDict):
     isbn: str
 
 
-class GetResponse(TypedDict):  # pylint: disable=duplicate-code
+class GetResponse(TypedDict):
     items: list[ReviewContents]
     keys: list[Union[ReviewItemKey, str]]
 

--- a/bee_slack_app/service/test_book_search.py
+++ b/bee_slack_app/service/test_book_search.py
@@ -1,5 +1,4 @@
 # pylint: disable=attribute-defined-outside-init
-# pylint: disable=duplicate-code
 # pylint: disable=non-ascii-name
 
 from bee_slack_app.service import book_search

--- a/bee_slack_app/service/test_review.py
+++ b/bee_slack_app/service/test_review.py
@@ -1,4 +1,3 @@
-# pylint: disable=duplicate-code
 # pylint: disable=non-ascii-name
 
 

--- a/bee_slack_app/service/test_user.py
+++ b/bee_slack_app/service/test_user.py
@@ -1,4 +1,3 @@
-# pylint: disable=duplicate-code
 # pylint: disable=non-ascii-name
 
 from logging import getLogger

--- a/bee_slack_app/service/user.py
+++ b/bee_slack_app/service/user.py
@@ -1,4 +1,3 @@
-# pylint: disable=duplicate-code
 from typing import Any, Optional
 
 from bee_slack_app.model.user import User

--- a/bee_slack_app/view_controller/book.py
+++ b/bee_slack_app/view_controller/book.py
@@ -1,6 +1,3 @@
-# pylint: disable=duplicate-code
-
-
 def book_controller(app):
     @app.action("see_more_recommended_book")
     def open_see_more_recommended_book_modal(ack, body, client):

--- a/bee_slack_app/view_controller/book_search.py
+++ b/bee_slack_app/view_controller/book_search.py
@@ -209,7 +209,7 @@ def book_search_controller(app):  # pylint: disable=too-many-statements
         ボタンが選択された本のblockを生成する
         """
         return {
-            "type": "actions",  # pylint: disable=duplicate-code
+            "type": "actions",
             "elements": [
                 {
                     "type": "button",

--- a/pylintrc
+++ b/pylintrc
@@ -8,3 +8,4 @@ disable=
     missing-function-docstring, 
     line-too-long,
     fixme,
+    duplicate-code,


### PR DESCRIPTION
テストコードやblock kit周りでエラーになることが多いが、
duplicate-codeを受けてコードを共通化するべき、となる場合がほとんどないので、全体で無効化する