### PR TITLE
Google Books APIでISBNからの検索結果が2つ以上のケースを考慮する

### DIFF
--- a/bee_slack_app/repository/google_books_repository.py
+++ b/bee_slack_app/repository/google_books_repository.py
@@ -85,7 +85,7 @@ class GoogleBooksRepository:
         # APIを実行して結果を取得する
         json_result = requests.get(self.base_url_google, param).json()
 
-        if json_result["totalItems"] != 1:
+        if json_result["totalItems"] == 0:
             return None
 
         _item = json_result["items"][0]


### PR DESCRIPTION
[ISBN: 9784478006658](https://www.googleapis.com/books/v1/volumes?q=isbn:9784478006658&country=JP) など、ISBNからの検索結果アイテムが2つ以上となるケースがある
この場合、1つ目のアイテムを検索結果として扱うように修正する