### PR TITLE
Lazyリスナを使わないようにする

### DIFF
--- a/bee_slack_app/view_controller/recommend.py
+++ b/bee_slack_app/view_controller/recommend.py
@@ -7,17 +7,18 @@ from bee_slack_app.service.user import get_user
 
 
 def recommend_controller(app):  # pylint: disable=too-many-statements
-    def open_recommend_modal(body, client, logger):
+    @app.action("book_recommend")
+    def open_recommend_modal(ack, body, client, logger):
+        ack()
+
         logger.info(body)
 
         user_id = body["user"]["id"]
 
         user: Optional[User] = get_user(logger, user_id)
         if not user:
-            # Lazyリスナーを使用している為、trigger_idを使用してviews_openはできない。
-            # external_idを使用してviews_updateで、show_waiting_messageモーダルを更新する。
-            client.views_update(
-                external_id="recommend_external_id",
+            client.views_open(
+                trigger_id=body["trigger_id"],
                 view={
                     "type": "modal",
                     "title": {
@@ -42,10 +43,8 @@ def recommend_controller(app):  # pylint: disable=too-many-statements
         book: Optional[SearchedBook] = recommend(logger, user)
 
         if book is None:
-            # Lazyリスナーを使用している為、trigger_idを使用してviews_openはできない。
-            # external_idを使用してviews_updateで、show_waiting_messageモーダルを更新する。
-            client.views_update(
-                external_id="recommend_external_id",
+            client.views_open(
+                trigger_id=body["trigger_id"],
                 view={
                     "type": "modal",
                     "title": {
@@ -69,10 +68,10 @@ def recommend_controller(app):  # pylint: disable=too-many-statements
 
         modal_view = generate_book_recommend_model_view(book)
 
-        client.views_update(
+        client.views_open(
+            trigger_id=body["trigger_id"],
             # ビューのペイロード
             view=modal_view,
-            external_id="recommend_external_id",
         )
 
     def generate_book_recommend_model_view(book: SearchedBook):
@@ -122,29 +121,3 @@ def recommend_controller(app):  # pylint: disable=too-many-statements
             ],
         }
         return view
-
-    def show_waiting_message(ack, body, client):
-        ack()
-
-        client.views_open(
-            trigger_id=body["trigger_id"],
-            view_id=body["view"]["id"],
-            view={
-                "type": "modal",
-                "callback_id": "recommend_book",
-                "external_id": "recommend_external_id",
-                "title": {"type": "plain_text", "text": "処理中", "emoji": True},
-                "close": {"type": "plain_text", "text": "閉じる", "emoji": True},
-                "blocks": [
-                    {
-                        "type": "section",
-                        "text": {"type": "mrkdwn", "text": "処理中です...\nしばらくお待ちください。"},
-                    },
-                ],
-            },
-        )
-
-    app.action("book_recommend")(
-        ack=show_waiting_message,
-        lazy=[open_recommend_modal],
-    )

--- a/serverless.yml
+++ b/serverless.yml
@@ -28,12 +28,6 @@ provider:
         - dynamodb:DeleteItem
       Resource:
         - "*"
-    - Effect: Allow
-      Action:
-        - lambda:InvokeFunction
-        - lambda:GetFunction
-      Resource:
-        - "*"
 
 functions:
   app:


### PR DESCRIPTION
https://github.com/esminc/boat-bee/issues/250 の現象はLazyリスナにおけるexternal_idの設定がうまくいかないことが原因だと思われる。

同バグの根本原因と対処方法は不明だが、現在、機械学習による予測処理はLazyリスナが必要なほど重くないので、Lazyリスナを使わないようにすることで、回避する。