### PR TITLE
pytestのverboseオプションを有効化

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ type-check:
 test: export AWS_DEFAULT_REGION := us-east-1
 test: export DYNAMODB_TABLE := bee-dev
 test:
-	pipenv run pytest
+	pipenv run pytest --verbose
 
 train:
 	cd ml && pipenv run python train.py


### PR DESCRIPTION
どんなテストが実行されているのかを、出力から把握したいので、verboseオプションを有効化したいです。

<img width="1275" alt="スクリーンショット 2022-05-30 14 04 27" src="https://user-images.githubusercontent.com/48438462/170920483-131b62e5-e36b-42ad-b3c4-d6b12aa71509.png">
