### PR TITLE
DynamoDBのテーブルを一つにまとめる

### DIFF
--- a/bee_slack_app/repository/book_repository_test.py
+++ b/bee_slack_app/repository/book_repository_test.py
@@ -1,45 +1,18 @@
 # pylint: disable=attribute-defined-outside-init
 # pylint: disable=non-ascii-name
 
-import os
 
-import boto3  # type: ignore
 from moto import mock_dynamodb  # type: ignore
 
 from bee_slack_app.model.book import Book
 from bee_slack_app.repository.book_repository import BookRepository
+from bee_slack_app.repository.database import create_table
 
 
 @mock_dynamodb
 class TestBookRepository:
     def setup_method(self, _):
-        dynamodb = boto3.resource("dynamodb")
-
-        self.table = dynamodb.create_table(
-            TableName=os.environ["DYNAMODB_TABLE"] + "-book",
-            AttributeDefinitions=[
-                {"AttributeName": "book_pk", "AttributeType": "S"},
-                {"AttributeName": "isbn", "AttributeType": "S"},
-                {"AttributeName": "updated_at", "AttributeType": "S"},
-            ],
-            KeySchema=[
-                {"AttributeName": "book_pk", "KeyType": "HASH"},
-                {"AttributeName": "isbn", "KeyType": "RANGE"},
-            ],
-            ProvisionedThroughput={"ReadCapacityUnits": 1, "WriteCapacityUnits": 1},
-            GlobalSecondaryIndexes=[
-                {
-                    "IndexName": "updatedAtIndex",
-                    "KeySchema": [
-                        {"AttributeName": "book_pk", "KeyType": "HASH"},
-                        {"AttributeName": "updated_at", "KeyType": "RANGE"},
-                    ],
-                    "Projection": {
-                        "ProjectionType": "ALL",
-                    },
-                }
-            ],
-        )
+        self.table = create_table()
 
     def test_本を保存できること(self):
 
@@ -57,26 +30,26 @@ class TestBookRepository:
 
         book_repository.put(book=item)
 
-        response = self.table.query(
-            KeyConditionExpression=boto3.dynamodb.conditions.Key("book_pk").eq(
-                "book_pk_value"
-            ),
-        )
+        response = self.table.get_item(Key={"PK": "book#12345"})
 
-        books_items = response["Items"]
+        books_item = response["Item"]
 
-        assert books_items[0]["book_pk"] == "book_pk_value"
-        assert books_items[0]["isbn"] == "12345"
-        assert books_items[0]["updated_at"] == "251753562000.0"
-        assert books_items[0]["title"] == "dummy_title"
-        assert books_items[0]["author"] == "dummy_author"
-        assert books_items[0]["url"] == "dummy_url"
-        assert books_items[0]["image_url"] == "dummy_image_url"
-        assert books_items[0]["description"] == "dummy_description"
+        assert books_item["PK"] == "book#12345"
+        assert books_item["GSI_PK"] == "book"
+        assert books_item["GSI_0_SK"] == "251753562000.0"
+        assert books_item["isbn"] == "12345"
+        assert books_item["updated_at"] == "251753562000.0"
+        assert books_item["title"] == "dummy_title"
+        assert books_item["author"] == "dummy_author"
+        assert books_item["url"] == "dummy_url"
+        assert books_item["image_url"] == "dummy_image_url"
+        assert books_item["description"] == "dummy_description"
 
     def test_本を取得できること(self):
         item = {
-            "book_pk": "book_pk_value",
+            "PK": "book#12345",
+            "GSI_PK": "book",
+            "GSI_0_SK": "251753562000.0",
             "isbn": "12345",
             "updated_at": "251753562000.0",
             "title": "dummy_title_0",
@@ -89,7 +62,9 @@ class TestBookRepository:
         self.table.put_item(Item=item)
 
         item = {
-            "book_pk": "book_pk_value",
+            "PK": "book#67890",
+            "GSI_PK": "book",
+            "GSI_0_SK": "251753475600.0",
             "isbn": "67890",
             "updated_at": "251753475600.0",
             "title": "dummy_title_1",
@@ -102,7 +77,9 @@ class TestBookRepository:
         self.table.put_item(Item=item)
 
         item = {
-            "book_pk": "book_pk_value",
+            "PK": "book#01234",
+            "GSI_PK": "book",
+            "GSI_0_SK": "251753389200.0",
             "isbn": "01234",
             "updated_at": "251753389200.0",
             "title": "dummy_title_2",
@@ -150,7 +127,9 @@ class TestBookRepository:
 
     def test_複数回に分けて本を取得できること(self):
         item = {
-            "book_pk": "book_pk_value",
+            "PK": "book#12345",
+            "GSI_PK": "book",
+            "GSI_0_SK": "251753562000.0",
             "isbn": "12345",
             "updated_at": "251753562000.0",
             "title": "dummy_title_0",
@@ -163,7 +142,9 @@ class TestBookRepository:
         self.table.put_item(Item=item)
 
         item = {
-            "book_pk": "book_pk_value",
+            "PK": "book#67890",
+            "GSI_PK": "book",
+            "GSI_0_SK": "251753475600.0",
             "isbn": "67890",
             "updated_at": "251753475600.0",
             "title": "dummy_title_1",
@@ -176,7 +157,9 @@ class TestBookRepository:
         self.table.put_item(Item=item)
 
         item = {
-            "book_pk": "book_pk_value",
+            "PK": "book#01234",
+            "GSI_PK": "book",
+            "GSI_0_SK": "251753389200.0",
             "isbn": "01234",
             "updated_at": "251753389200.0",
             "title": "dummy_title_2",
@@ -231,11 +214,7 @@ class TestBookRepository:
         assert books_items[0]["updated_at"] == "2022-04-01T00:00:00+09:00"
 
     def test_本が存在しない場合は空配列を返すこと(self):  # pylint: disable=invalid-name
-        response = self.table.query(
-            KeyConditionExpression=boto3.dynamodb.conditions.Key("book_pk").eq(
-                "book_pk_value"
-            ),
-        )
+        response = self.table.scan()
 
         assert len(response["Items"]) == 0
 

--- a/bee_slack_app/repository/database.py
+++ b/bee_slack_app/repository/database.py
@@ -2,6 +2,16 @@ import os
 
 import boto3  # type: ignore
 
+PK = "PK"
+
+GSI_0 = "GSI_0"
+GSI_1 = "GSI_1"
+GSI_2 = "GSI_2"
+GSI_PK = "GSI_PK"
+GSI_0_SK = "GSI_0_SK"
+GSI_1_SK = "GSI_1_SK"
+GSI_2_SK = "GSI_2_SK"
+
 
 def get_database_client():
     """
@@ -12,3 +22,55 @@ def get_database_client():
     dynamodb = boto3.resource("dynamodb", endpoint_url=endpoint_url)
 
     return dynamodb
+
+
+def get_table():
+    return get_database_client().Table(os.environ["DYNAMODB_TABLE"])
+
+
+def create_table():
+    """
+    テスト用にテーブルを作成する
+    """
+    dynamodb = boto3.resource("dynamodb")
+
+    return dynamodb.create_table(
+        TableName=os.environ["DYNAMODB_TABLE"],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "GSI_PK", "AttributeType": "S"},
+            {"AttributeName": "GSI_0_SK", "AttributeType": "S"},
+            {"AttributeName": "GSI_1_SK", "AttributeType": "S"},
+            {"AttributeName": "GSI_2_SK", "AttributeType": "S"},
+        ],
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+        ],
+        ProvisionedThroughput={"ReadCapacityUnits": 1, "WriteCapacityUnits": 1},
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "GSI_0",
+                "KeySchema": [
+                    {"AttributeName": "GSI_PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI_0_SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "GSI_1",
+                "KeySchema": [
+                    {"AttributeName": "GSI_PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI_1_SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "GSI_2",
+                "KeySchema": [
+                    {"AttributeName": "GSI_PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI_2_SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+        ],
+    )

--- a/bee_slack_app/repository/review_repository.py
+++ b/bee_slack_app/repository/review_repository.py
@@ -1,12 +1,15 @@
-import os
 from typing import Optional, TypedDict
 
 from boto3.dynamodb.conditions import Key  # type: ignore
 
 from bee_slack_app.model.review import ReviewContents
-from bee_slack_app.repository.database import get_database_client
+from bee_slack_app.repository import database
 
-REVIEW_ISBN_GSI = "IsbnIndex"
+GSI_PK_VALUE = "review"
+
+
+def _encode_partition_key(*, user_id: str, isbn: str) -> str:
+    return f"review#{user_id}#{isbn}"
 
 
 # This is a sample
@@ -16,9 +19,7 @@ class ReviewRepository:
         score_for_others: Optional[str]
 
     def __init__(self):
-        self.table = get_database_client().Table(
-            os.environ["DYNAMODB_TABLE"] + "-review"
-        )
+        self.table = database.get_table()
 
     def get(self, *, user_id: str, isbn: str) -> Optional[ReviewContents]:
         """
@@ -30,12 +31,8 @@ class ReviewRepository:
         Returns:
             本のレビュー。存在しない場合はNone。
         """
-        return self.table.get_item(
-            Key={
-                "user_id": user_id,
-                "isbn": isbn,
-            }
-        ).get("Item")
+        partition_key = _encode_partition_key(user_id=user_id, isbn=isbn)
+        return self.table.get_item(Key={database.PK: partition_key}).get("Item")
 
     def get_all(self) -> list[ReviewContents]:
         """
@@ -44,21 +41,24 @@ class ReviewRepository:
         Returns: 本のレビューのリスト
         """
 
-        def scan(exclusive_start_key=None):
+        def query(exclusive_start_key=None):
             option = {}
             if exclusive_start_key:
                 option["ExclusiveStartKey"] = exclusive_start_key
 
-            response = self.table.scan(**option)
+            response = self.table.query(
+                IndexName=database.GSI_0,
+                KeyConditionExpression=Key(database.GSI_PK).eq(GSI_PK_VALUE),
+            )
 
             return response["Items"], response.get("LastEvaluatedKey")
 
-        items, last_key = scan()
+        items, last_key = query()
 
         # レスポンスに LastEvaluatedKey が含まれなくなるまでループ処理を実行する
         # see https://dev.classmethod.jp/articles/hot-to-get-more-than-1mb-of-data-from-dynamodb-when-using-scan/
         while last_key is not None:
-            new_items, last_key = scan(exclusive_start_key=last_key)
+            new_items, last_key = query(exclusive_start_key=last_key)
             items.extend(new_items)
 
         return items
@@ -73,12 +73,22 @@ class ReviewRepository:
             レビューのリスト。指定したISBNで見つからない場合は空のリストを返す。
         """
         return self.table.query(
-            IndexName=REVIEW_ISBN_GSI,
-            KeyConditionExpression=Key("isbn").eq(isbn),
+            IndexName=database.GSI_2,
+            KeyConditionExpression=Key(database.GSI_PK).eq(GSI_PK_VALUE)
+            & Key(database.GSI_2_SK).eq(isbn),
         )["Items"]
 
     def create(self, review):
+        partition_key = _encode_partition_key(
+            user_id=review["user_id"], isbn=review["isbn"]
+        )
+
         item = {
+            database.PK: partition_key,
+            database.GSI_PK: GSI_PK_VALUE,
+            database.GSI_0_SK: review["updated_at"],
+            database.GSI_1_SK: review["user_id"],
+            database.GSI_2_SK: review["isbn"],
             "user_id": review["user_id"],
             "book_title": review["book_title"],
             "isbn": review["isbn"],

--- a/bee_slack_app/repository/review_repository_test.py
+++ b/bee_slack_app/repository/review_repository_test.py
@@ -1,44 +1,26 @@
 # pylint: disable=attribute-defined-outside-init
 # pylint: disable=non-ascii-name
 
-import os
 
 import boto3  # type: ignore
 from moto import mock_dynamodb  # type: ignore
 
+from bee_slack_app.repository.database import create_table
 from bee_slack_app.repository.review_repository import ReviewRepository
 
 
 @mock_dynamodb
 class TestReview:
     def setup_method(self, _):
-        dynamodb = boto3.resource("dynamodb")
-
-        self.table = dynamodb.create_table(
-            TableName=os.environ["DYNAMODB_TABLE"] + "-review",
-            AttributeDefinitions=[
-                {"AttributeName": "user_id", "AttributeType": "S"},
-                {"AttributeName": "isbn", "AttributeType": "S"},
-            ],
-            KeySchema=[
-                {"AttributeName": "user_id", "KeyType": "HASH"},
-                {"AttributeName": "isbn", "KeyType": "RANGE"},
-            ],
-            GlobalSecondaryIndexes=[
-                {
-                    "IndexName": "IsbnIndex",
-                    "KeySchema": [
-                        {"AttributeName": "isbn", "KeyType": "HASH"},
-                        {"AttributeName": "user_id", "KeyType": "RANGE"},
-                    ],
-                    "Projection": {"ProjectionType": "ALL"},
-                }
-            ],
-            ProvisionedThroughput={"ReadCapacityUnits": 1, "WriteCapacityUnits": 1},
-        )
+        self.table = create_table()
 
     def test_ISBNからレビューを取得できること(self):  # pylint: disable=invalid-name
         item = {
+            "PK": "review#user_id_0#12345",
+            "GSI_PK": "review",
+            "GSI_0_SK": "2022-04-01T00:00:00+09:00",
+            "GSI_1_SK": "user_id_0",
+            "GSI_2_SK": "12345",
             "user_id": "user_id_0",
             "book_title": "仕事ではじめる機械学習",
             "isbn": "12345",
@@ -54,6 +36,11 @@ class TestReview:
         self.table.put_item(Item=item)
 
         item = {
+            "PK": "review#user_id_1#12345",
+            "GSI_PK": "review",
+            "GSI_0_SK": "2022-04-01T00:00:00+09:00",
+            "GSI_1_SK": "user_id_1",
+            "GSI_2_SK": "12345",
             "user_id": "user_id_1",
             "book_title": "仕事ではじめる機械学習",
             "isbn": "12345",
@@ -69,6 +56,11 @@ class TestReview:
         self.table.put_item(Item=item)
 
         item = {
+            "PK": "review#user_id_2#67890",
+            "GSI_PK": "review",
+            "GSI_0_SK": "2022-04-01T00:00:00+09:00",
+            "GSI_1_SK": "user_id_2",
+            "GSI_2_SK": "67890",
             "user_id": "user_id_2",
             "book_title": "Python チュートリアル",
             "isbn": "67890",
@@ -111,6 +103,11 @@ class TestReview:
 
     def test_テーブルに存在しないレビューのISBNを指定した場合_空配列を返すこと(self):  # pylint: disable=invalid-name
         item = {
+            "PK": "review#user_id_0#12345",
+            "GSI_PK": "review",
+            "GSI_0_SK": "2022-04-01T00:00:00+09:00",
+            "GSI_1_SK": "user_id_0",
+            "GSI_2_SK": "12345",
             "user_id": "user_id_0",
             "book_title": "仕事ではじめる機械学習",
             "isbn": "12345",
@@ -126,6 +123,11 @@ class TestReview:
         self.table.put_item(Item=item)
 
         item = {
+            "PK": "review#user_id_1#12345",
+            "GSI_PK": "review",
+            "GSI_0_SK": "2022-04-01T00:00:00+09:00",
+            "GSI_1_SK": "user_id_1",
+            "GSI_2_SK": "12345",
             "user_id": "user_id_1",
             "book_title": "仕事ではじめる機械学習",
             "isbn": "12345",
@@ -141,6 +143,11 @@ class TestReview:
         self.table.put_item(Item=item)
 
         item = {
+            "PK": "review#user_id_2#67890",
+            "GSI_PK": "review",
+            "GSI_0_SK": "2022-04-01T00:00:00+09:00",
+            "GSI_1_SK": "user_id_2",
+            "GSI_2_SK": "67890",
             "user_id": "user_id_2",
             "book_title": "Python チュートリアル",
             "isbn": "67890",
@@ -164,6 +171,11 @@ class TestReview:
 
     def test_レビューを一意に指定して取得できること(self):
         item = {
+            "PK": "review#user_id_0#12345",
+            "GSI_PK": "review",
+            "GSI_0_SK": "2022-04-01T00:00:00+09:00",
+            "GSI_1_SK": "user_id_0",
+            "GSI_2_SK": "12345",
             "user_id": "user_id_0",
             "book_title": "仕事ではじめる機械学習",
             "isbn": "12345",
@@ -180,6 +192,11 @@ class TestReview:
         self.table.put_item(Item=item)
 
         item = {
+            "PK": "review#user_id_1#12345",
+            "GSI_PK": "review",
+            "GSI_0_SK": "2022-04-01T00:00:00+09:00",
+            "GSI_1_SK": "user_id_1",
+            "GSI_2_SK": "12345",
             "user_id": "user_id_1",
             "book_title": "仕事ではじめる機械学習",
             "isbn": "12345",
@@ -196,6 +213,11 @@ class TestReview:
         self.table.put_item(Item=item)
 
         item = {
+            "PK": "review#user_id_2#67890",
+            "GSI_PK": "review",
+            "GSI_0_SK": "2022-04-01T00:00:00+09:00",
+            "GSI_1_SK": "user_id_2",
+            "GSI_2_SK": "67890",
             "user_id": "user_id_2",
             "book_title": "Python チュートリアル",
             "isbn": "67890",
@@ -228,6 +250,11 @@ class TestReview:
 
     def test_存在しないレビューを指定した場合_Noneを返すこと(self):  # pylint: disable=invalid-name
         item = {
+            "PK": "review#user_id_0#12345",
+            "GSI_PK": "review",
+            "GSI_0_SK": "2022-04-01T00:00:00+09:00",
+            "GSI_1_SK": "user_id_0",
+            "GSI_2_SK": "12345",
             "user_id": "user_id_0",
             "book_title": "仕事ではじめる機械学習",
             "isbn": "12345",
@@ -244,6 +271,11 @@ class TestReview:
         self.table.put_item(Item=item)
 
         item = {
+            "PK": "review#user_id_1#12345",
+            "GSI_PK": "review",
+            "GSI_0_SK": "2022-04-01T00:00:00+09:00",
+            "GSI_1_SK": "user_id_1",
+            "GSI_2_SK": "12345",
             "user_id": "user_id_1",
             "book_title": "仕事ではじめる機械学習",
             "isbn": "12345",
@@ -260,6 +292,11 @@ class TestReview:
         self.table.put_item(Item=item)
 
         item = {
+            "PK": "review#user_id_2#67890",
+            "GSI_PK": "review",
+            "GSI_0_SK": "2022-04-01T00:00:00+09:00",
+            "GSI_1_SK": "user_id_2",
+            "GSI_2_SK": "67890",
             "user_id": "user_id_2",
             "book_title": "Python チュートリアル",
             "isbn": "67890",
@@ -283,6 +320,11 @@ class TestReview:
 
     def test_全件取得でレビューを取得できること(self):
         item = {
+            "PK": "review#user_id_0#12345",
+            "GSI_PK": "review",
+            "GSI_0_SK": "2022-04-01T00:00:00+09:00",
+            "GSI_1_SK": "user_id_0",
+            "GSI_2_SK": "12345",
             "user_id": "user_id_0",
             "book_title": "仕事ではじめる機械学習",
             "isbn": "12345",
@@ -299,6 +341,11 @@ class TestReview:
         self.table.put_item(Item=item)
 
         item = {
+            "PK": "review#user_id_1#12345",
+            "GSI_PK": "review",
+            "GSI_0_SK": "2022-04-01T00:00:00+09:00",
+            "GSI_1_SK": "user_id_1",
+            "GSI_2_SK": "12345",
             "user_id": "user_id_1",
             "book_title": "仕事ではじめる機械学習",
             "isbn": "12345",
@@ -315,6 +362,11 @@ class TestReview:
         self.table.put_item(Item=item)
 
         item = {
+            "PK": "review#user_id_2#67890",
+            "GSI_PK": "review",
+            "GSI_0_SK": "2022-04-02T00:00:00+09:00",
+            "GSI_1_SK": "user_id_2",
+            "GSI_2_SK": "67890",
             "user_id": "user_id_2",
             "book_title": "Python チュートリアル",
             "isbn": "67890",
@@ -382,13 +434,9 @@ class TestReview:
         assert isinstance(reviews, list)
 
     def test_レビューを作成できること(self):
-        response = self.table.query(
-            KeyConditionExpression=boto3.dynamodb.conditions.Key("user_id").eq(
-                "test_user_id"
-            ),
-        )
+        item = self.table.get_item(Key={"PK": "review#test_user_id#12345"}).get("Item")
 
-        assert len(response["Items"]) == 0
+        assert item is None
 
         review_repository = ReviewRepository()
 
@@ -408,16 +456,14 @@ class TestReview:
             }
         )
 
-        response = self.table.query(
-            KeyConditionExpression=boto3.dynamodb.conditions.Key("user_id").eq(
-                "test_user_id"
-            ),
+        actual = self.table.get_item(Key={"PK": "review#test_user_id#12345"}).get(
+            "Item"
         )
-
-        assert len(response["Items"]) == 1
-
-        actual = response["Items"][0]
-
+        assert actual["PK"] == "review#test_user_id#12345"
+        assert actual["GSI_PK"] == "review"
+        assert actual["GSI_0_SK"] == "2022-04-01T00:00:00+09:00"
+        assert actual["GSI_1_SK"] == "test_user_id"
+        assert actual["GSI_2_SK"] == "12345"
         assert actual["user_id"] == "test_user_id"
         assert actual["isbn"] == "12345"
         assert actual["book_title"] == "本のタイトル"
@@ -449,16 +495,15 @@ class TestReview:
             }
         )
 
-        response = self.table.query(
-            KeyConditionExpression=boto3.dynamodb.conditions.Key("user_id").eq(
-                "test_user_id"
-            ),
+        actual = self.table.get_item(Key={"PK": "review#test_user_id#12345"}).get(
+            "Item"
         )
 
-        assert len(response["Items"]) == 1
-
-        actual = response["Items"][0]
-
+        assert actual["PK"] == "review#test_user_id#12345"
+        assert actual["GSI_PK"] == "review"
+        assert actual["GSI_0_SK"] == "2022-04-01T00:00:00+09:00"
+        assert actual["GSI_1_SK"] == "test_user_id"
+        assert actual["GSI_2_SK"] == "12345"
         assert actual["user_id"] == "test_user_id"
         assert actual["isbn"] == "12345"
         assert actual["book_title"] == "最初のレビューのタイトル"
@@ -487,16 +532,15 @@ class TestReview:
             }
         )
 
-        response = self.table.query(
-            KeyConditionExpression=boto3.dynamodb.conditions.Key("user_id").eq(
-                "test_user_id"
-            ),
+        actual = self.table.get_item(Key={"PK": "review#test_user_id#12345"}).get(
+            "Item"
         )
 
-        assert len(response["Items"]) == 1
-
-        actual = response["Items"][0]
-
+        assert actual["PK"] == "review#test_user_id#12345"
+        assert actual["GSI_PK"] == "review"
+        assert actual["GSI_0_SK"] == "2022-04-02T00:00:00+09:00"
+        assert actual["GSI_1_SK"] == "test_user_id"
+        assert actual["GSI_2_SK"] == "12345"
         assert actual["user_id"] == "test_user_id"
         assert actual["isbn"] == "12345"
         assert actual["book_title"] == "上書き後のレビューのタイトル"
@@ -552,16 +596,15 @@ class TestReview:
             }
         )
 
-        response = self.table.query(
-            KeyConditionExpression=boto3.dynamodb.conditions.Key("user_id").eq(
-                "test_user_id"
-            ),
+        actual_0 = self.table.get_item(Key={"PK": "review#test_user_id#12345"}).get(
+            "Item"
         )
 
-        assert len(response["Items"]) == 2
-
-        actual_0 = response["Items"][0]
-
+        assert actual_0["PK"] == "review#test_user_id#12345"
+        assert actual_0["GSI_PK"] == "review"
+        assert actual_0["GSI_0_SK"] == "2022-04-01T00:00:00+09:00"
+        assert actual_0["GSI_1_SK"] == "test_user_id"
+        assert actual_0["GSI_2_SK"] == "12345"
         assert actual_0["user_id"] == "test_user_id"
         assert actual_0["isbn"] == "12345"
         assert actual_0["book_title"] == "本のタイトル"
@@ -574,8 +617,15 @@ class TestReview:
         assert actual_0["book_url"] == "dummy_book_url_0"
         assert actual_0["book_description"] == "dummy_description_0"
 
-        actual_1 = response["Items"][1]
+        actual_1 = self.table.get_item(Key={"PK": "review#test_user_id#67890"}).get(
+            "Item"
+        )
 
+        assert actual_1["PK"] == "review#test_user_id#67890"
+        assert actual_1["GSI_PK"] == "review"
+        assert actual_1["GSI_0_SK"] == "2022-05-01T00:00:00+09:00"
+        assert actual_1["GSI_1_SK"] == "test_user_id"
+        assert actual_1["GSI_2_SK"] == "67890"
         assert actual_1["user_id"] == "test_user_id"
         assert actual_1["isbn"] == "67890"
         assert actual_1["book_title"] == "本のタイトル"

--- a/bee_slack_app/repository/suggested_book_repository.py
+++ b/bee_slack_app/repository/suggested_book_repository.py
@@ -1,31 +1,20 @@
 """おすすめされた本を、追加・更新します
 """
-import os
 from typing import Optional
 
 from bee_slack_app.model.suggested_book import SuggestedBook
-from bee_slack_app.repository.database import get_database_client
+from bee_slack_app.repository import database
+
+GSI_PK_VALUE = "suggested_book"
 
 
-# DBソートキーの生成
-def encode_sort_key(isbn: str, ml_model: str) -> str:
-    return isbn + "#" + ml_model
-
-
-# DBソートキーの分解
-def decode_sort_key(sort_key: str) -> tuple[str, str]:
-    # sort keyにはisbnとml_model情報が#で連結されて入っている
-    items = sort_key.split("#")
-    isbn = items[0]
-    ml_model = items[1]
-    return (isbn, ml_model)
+def _encode_partition_key(*, user_id: str, isbn: str, ml_model: str) -> str:
+    return f"suggested_book#{user_id}#{isbn}#{ml_model}"
 
 
 class SuggestedBookRepository:
     def __init__(self):
-        self.table = get_database_client().Table(
-            os.environ["DYNAMODB_TABLE"] + "-suggested-book"
-        )
+        self.table = database.get_table()
 
     def get(self, *, user_id: str, isbn: str, ml_model: str) -> Optional[SuggestedBook]:
         """
@@ -39,35 +28,33 @@ class SuggestedBookRepository:
         Returns:
             SuggestedBook: おすすめされた本の情報を返す。未登録の場合は、Noneを返します。
         """
-        response = self.table.get_item(
+        return self.table.get_item(
             Key={
-                "user_id": user_id,
-                "suggested_book_sk": encode_sort_key(isbn, ml_model),
+                database.PK: _encode_partition_key(
+                    user_id=user_id, isbn=isbn, ml_model=ml_model
+                ),
             }
-        )
-        item = response.get("Item")
-        if item is None:
-            return None
-
-        isbn, ml_model = decode_sort_key(item["suggested_book_sk"])
-        suggested_book: SuggestedBook = {
-            "user_id": item["user_id"],
-            "isbn": isbn,
-            "ml_model": ml_model,
-            "interested": item["interested"],
-            "updated_at": item["updated_at"],
-        }
-        return suggested_book
+        ).get("Item")
 
     def create(self, suggested_book: SuggestedBook) -> None:
         """
         データを追加および上書きします
         """
+        partition_key = _encode_partition_key(
+            user_id=suggested_book["user_id"],
+            isbn=suggested_book["isbn"],
+            ml_model=suggested_book["ml_model"],
+        )
+
         item = {
+            database.PK: partition_key,
+            database.GSI_PK: GSI_PK_VALUE,
+            database.GSI_0_SK: suggested_book["user_id"],
+            database.GSI_1_SK: suggested_book["isbn"],
+            database.GSI_2_SK: suggested_book["ml_model"],
             "user_id": suggested_book["user_id"],
-            "suggested_book_sk": encode_sort_key(
-                suggested_book["isbn"], suggested_book["ml_model"]
-            ),
+            "isbn": suggested_book["isbn"],
+            "ml_model": suggested_book["ml_model"],
             "interested": suggested_book["interested"],
             "updated_at": suggested_book["updated_at"],
         }

--- a/bee_slack_app/repository/suggested_book_repository_test.py
+++ b/bee_slack_app/repository/suggested_book_repository_test.py
@@ -1,36 +1,28 @@
 # pylint: disable=attribute-defined-outside-init
 # pylint: disable=non-ascii-name
 
-import os
 
-import boto3  # type: ignore
 from moto import mock_dynamodb  # type: ignore
 
+from bee_slack_app.repository import database
 from bee_slack_app.repository.suggested_book_repository import SuggestedBookRepository
 
 
 @mock_dynamodb
 class TestSuggestedBookRepository:
     def setup_method(self, _):
-        dynamodb = boto3.resource("dynamodb")
-
-        self.table = dynamodb.create_table(
-            TableName=os.environ["DYNAMODB_TABLE"] + "-suggested-book",
-            AttributeDefinitions=[
-                {"AttributeName": "user_id", "AttributeType": "S"},
-                {"AttributeName": "suggested_book_sk", "AttributeType": "S"},
-            ],
-            KeySchema=[
-                {"AttributeName": "user_id", "KeyType": "HASH"},
-                {"AttributeName": "suggested_book_sk", "KeyType": "RANGE"},
-            ],
-            ProvisionedThroughput={"ReadCapacityUnits": 1, "WriteCapacityUnits": 1},
-        )
+        self.table = database.create_table()
 
     def test_DBの先頭にあるおすすめされた本を取得できること(self):  # pylint: disable=invalid-name
         item = {
+            "PK": "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_0",
+            "GSI_PK": "suggested_book",
+            "GSI_0_SK": "test_user_id_0",
+            "GSI_1_SK": "1234567890123",
+            "GSI_2_SK": "dummy_ml_model_0",
             "user_id": "test_user_id_0",
-            "suggested_book_sk": "1234567890123#dummy_ml_model_0",
+            "isbn": "1234567890123",
+            "ml_model": "dummy_ml_model_0",
             "interested": True,
             "updated_at": "2022-04-01T00:00:00+09:00",
         }
@@ -38,8 +30,14 @@ class TestSuggestedBookRepository:
         self.table.put_item(Item=item)
 
         item = {
+            "PK": "suggested_book#test_user_id_1#9234567890123#dummy_ml_model_1",
+            "GSI_PK": "suggested_book",
+            "GSI_0_SK": "test_user_id_1",
+            "GSI_1_SK": "9234567890123",
+            "GSI_2_SK": "dummy_ml_model_1",
             "user_id": "test_user_id_1",
-            "suggested_book_sk": "9234567890123#dummy_ml_model_1",
+            "isbn": "1234567890123",
+            "ml_model": "dummy_ml_model_1",
             "interested": True,
             "updated_at": "2022-04-11T09:23:04+09:00",
         }
@@ -60,8 +58,14 @@ class TestSuggestedBookRepository:
 
     def test_DBの最後尾にあるおすすめされた本を取得できること(self):  # pylint: disable=invalid-name
         item = {
+            "PK": "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_0",
+            "GSI_PK": "suggested_book",
+            "GSI_0_SK": "test_user_id_0",
+            "GSI_1_SK": "1234567890123",
+            "GSI_2_SK": "dummy_ml_model_0",
             "user_id": "test_user_id_0",
-            "suggested_book_sk": "1234567890123#dummy_ml_model_0",
+            "isbn": "1234567890123",
+            "ml_model": "dummy_ml_model_0",
             "interested": True,
             "updated_at": "2022-04-01T00:00:00+09:00",
         }
@@ -69,8 +73,14 @@ class TestSuggestedBookRepository:
         self.table.put_item(Item=item)
 
         item = {
+            "PK": "suggested_book#test_user_id_1#9234567890123#dummy_ml_model_1",
+            "GSI_PK": "suggested_book",
+            "GSI_0_SK": "test_user_id_1",
+            "GSI_1_SK": "9234567890123",
+            "GSI_2_SK": "dummy_ml_model_1",
             "user_id": "test_user_id_1",
-            "suggested_book_sk": "9234567890123#dummy_ml_model_1",
+            "isbn": "9234567890123",
+            "ml_model": "dummy_ml_model_1",
             "interested": False,
             "updated_at": "2022-04-11T09:23:04+09:00",
         }
@@ -91,8 +101,14 @@ class TestSuggestedBookRepository:
 
     def test_おすすめされた本が無い場合にNoneが返ること(self):  # pylint: disable=invalid-name
         item = {
+            "PK": "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_0",
+            "GSI_PK": "suggested_book",
+            "GSI_0_SK": "test_user_id_0",
+            "GSI_1_SK": "1234567890123",
+            "GSI_2_SK": "dummy_ml_model_0",
             "user_id": "test_user_id_0",
-            "suggested_book_sk": "1234567890123#dummy_ml_model_0",
+            "isbn": "1234567890123",
+            "ml_model": "dummy_ml_model_0",
             "interested": True,
             "updated_at": "2022-04-01T00:00:00+09:00",
         }
@@ -100,8 +116,14 @@ class TestSuggestedBookRepository:
         self.table.put_item(Item=item)
 
         item = {
+            "PK": "suggested_book#test_user_id_1#9234567890123#dummy_ml_model_1",
+            "GSI_PK": "suggested_book",
+            "GSI_0_SK": "test_user_id_1",
+            "GSI_1_SK": "9234567890123",
+            "GSI_2_SK": "dummy_ml_model_1",
             "user_id": "test_user_id_1",
-            "suggested_book_sk": "9234567890123#dummy_ml_model_1",
+            "isbn": "1234567890123",
+            "ml_model": "dummy_ml_model_1",
             "interested": False,
             "updated_at": "2022-04-11T09:23:04+09:00",
         }
@@ -117,13 +139,11 @@ class TestSuggestedBookRepository:
         assert suggested_book is None
 
     def test_おすすめされた本の情報を作成できること(self):
-        response = self.table.query(
-            KeyConditionExpression=boto3.dynamodb.conditions.Key("user_id").eq(
-                "test_user_id_0"
-            ),
-        )
+        actual = self.table.get_item(
+            Key={"PK": "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_0"}
+        ).get("Item")
 
-        assert len(response["Items"]) == 0
+        assert actual is None
 
         suggested_book_repository = SuggestedBookRepository()
 
@@ -137,28 +157,30 @@ class TestSuggestedBookRepository:
             }
         )
 
-        response = self.table.query(
-            KeyConditionExpression=boto3.dynamodb.conditions.Key("user_id").eq(
-                "test_user_id_0"
-            ),
+        actual = self.table.get_item(
+            Key={"PK": "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_0"}
+        ).get("Item")
+
+        assert (
+            actual["PK"]
+            == "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_0"
         )
-        assert len(response["Items"]) == 1
-
-        actual = response["Items"][0]
-
+        assert actual["GSI_PK"] == "suggested_book"
+        assert actual["GSI_0_SK"] == "test_user_id_0"
+        assert actual["GSI_1_SK"] == "1234567890123"
+        assert actual["GSI_2_SK"] == "dummy_ml_model_0"
         assert actual["user_id"] == "test_user_id_0"
-        assert actual["suggested_book_sk"] == "1234567890123#dummy_ml_model_0"
+        assert actual["isbn"] == "1234567890123"
+        assert actual["ml_model"] == "dummy_ml_model_0"
         assert actual["interested"] is True
         assert actual["updated_at"] == "2022-04-01T00:00:00+09:00"
 
     def test_ユーザーが同じでisbnとmlが異なるおすすめされた本を追加できること(self):
-        response = self.table.query(
-            KeyConditionExpression=boto3.dynamodb.conditions.Key("user_id").eq(
-                "test_user_id_0"
-            ),
-        )
+        actual = self.table.get_item(
+            Key={"PK": "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_0"}
+        ).get("Item")
 
-        assert len(response["Items"]) == 0
+        assert actual is None
 
         suggested_book_repository = SuggestedBookRepository()
 
@@ -172,17 +194,22 @@ class TestSuggestedBookRepository:
                 "updated_at": "2022-04-01T00:00:00+09:00",
             }
         )
-        response = self.table.query(
-            KeyConditionExpression=boto3.dynamodb.conditions.Key("user_id").eq(
-                "test_user_id_0"
-            ),
+
+        actual = self.table.get_item(
+            Key={"PK": "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_0"}
+        ).get("Item")
+
+        assert (
+            actual["PK"]
+            == "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_0"
         )
-        assert len(response["Items"]) == 1
-
-        actual = response["Items"][0]
-
+        assert actual["GSI_PK"] == "suggested_book"
+        assert actual["GSI_0_SK"] == "test_user_id_0"
+        assert actual["GSI_1_SK"] == "1234567890123"
+        assert actual["GSI_2_SK"] == "dummy_ml_model_0"
         assert actual["user_id"] == "test_user_id_0"
-        assert actual["suggested_book_sk"] == "1234567890123#dummy_ml_model_0"
+        assert actual["isbn"] == "1234567890123"
+        assert actual["ml_model"] == "dummy_ml_model_0"
         assert actual["interested"] is True
         assert actual["updated_at"] == "2022-04-01T00:00:00+09:00"
 
@@ -196,34 +223,48 @@ class TestSuggestedBookRepository:
                 "updated_at": "2022-04-01T00:00:00+09:00",
             }
         )
-        response = self.table.query(
-            KeyConditionExpression=boto3.dynamodb.conditions.Key("user_id").eq(
-                "test_user_id_0"
-            ),
+        actual = self.table.get_item(
+            Key={"PK": "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_0"}
+        ).get("Item")
+
+        assert (
+            actual["PK"]
+            == "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_0"
         )
-        assert len(response["Items"]) == 2
-
-        actual = response["Items"][0]
-
+        assert actual["GSI_PK"] == "suggested_book"
+        assert actual["GSI_0_SK"] == "test_user_id_0"
+        assert actual["GSI_1_SK"] == "1234567890123"
+        assert actual["GSI_2_SK"] == "dummy_ml_model_0"
         assert actual["user_id"] == "test_user_id_0"
-        assert actual["suggested_book_sk"] == "1234567890123#dummy_ml_model_0"
+        assert actual["isbn"] == "1234567890123"
+        assert actual["ml_model"] == "dummy_ml_model_0"
         assert actual["interested"] is True
         assert actual["updated_at"] == "2022-04-01T00:00:00+09:00"
 
-        actual = response["Items"][1]
+        actual = self.table.get_item(
+            Key={"PK": "suggested_book#test_user_id_0#9234567890123#dummy_ml_model_1"}
+        ).get("Item")
 
+        assert (
+            actual["PK"]
+            == "suggested_book#test_user_id_0#9234567890123#dummy_ml_model_1"
+        )
+        assert actual["GSI_PK"] == "suggested_book"
+        assert actual["GSI_0_SK"] == "test_user_id_0"
+        assert actual["GSI_1_SK"] == "9234567890123"
+        assert actual["GSI_2_SK"] == "dummy_ml_model_1"
         assert actual["user_id"] == "test_user_id_0"
-        assert actual["suggested_book_sk"] == "9234567890123#dummy_ml_model_1"
+        assert actual["isbn"] == "9234567890123"
+        assert actual["ml_model"] == "dummy_ml_model_1"
         assert actual["interested"] is True
         assert actual["updated_at"] == "2022-04-01T00:00:00+09:00"
 
     def test_ユーザーとisbnが同じでmlが異なるおすすめされた本を追加できること(self):
-        response = self.table.query(
-            KeyConditionExpression=boto3.dynamodb.conditions.Key("user_id").eq(
-                "test_user_id_0"
-            ),
-        )
-        assert len(response["Items"]) == 0
+        actual = self.table.get_item(
+            Key={"PK": "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_0"}
+        ).get("Item")
+
+        assert actual is None
 
         suggested_book_repository = SuggestedBookRepository()
 
@@ -237,17 +278,21 @@ class TestSuggestedBookRepository:
                 "updated_at": "2022-04-01T00:00:00+09:00",
             }
         )
-        response = self.table.query(
-            KeyConditionExpression=boto3.dynamodb.conditions.Key("user_id").eq(
-                "test_user_id_0"
-            ),
+        actual = self.table.get_item(
+            Key={"PK": "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_0"}
+        ).get("Item")
+
+        assert (
+            actual["PK"]
+            == "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_0"
         )
-        assert len(response["Items"]) == 1
-
-        actual = response["Items"][0]
-
+        assert actual["GSI_PK"] == "suggested_book"
+        assert actual["GSI_0_SK"] == "test_user_id_0"
+        assert actual["GSI_1_SK"] == "1234567890123"
+        assert actual["GSI_2_SK"] == "dummy_ml_model_0"
         assert actual["user_id"] == "test_user_id_0"
-        assert actual["suggested_book_sk"] == "1234567890123#dummy_ml_model_0"
+        assert actual["isbn"] == "1234567890123"
+        assert actual["ml_model"] == "dummy_ml_model_0"
         assert actual["interested"] is True
         assert actual["updated_at"] == "2022-04-01T00:00:00+09:00"
 
@@ -261,34 +306,48 @@ class TestSuggestedBookRepository:
                 "updated_at": "2022-04-01T00:00:00+09:00",
             }
         )
-        response = self.table.query(
-            KeyConditionExpression=boto3.dynamodb.conditions.Key("user_id").eq(
-                "test_user_id_0"
-            ),
+        actual = self.table.get_item(
+            Key={"PK": "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_0"}
+        ).get("Item")
+
+        assert (
+            actual["PK"]
+            == "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_0"
         )
-        assert len(response["Items"]) == 2
-
-        actual = response["Items"][0]
-
+        assert actual["GSI_PK"] == "suggested_book"
+        assert actual["GSI_0_SK"] == "test_user_id_0"
+        assert actual["GSI_1_SK"] == "1234567890123"
+        assert actual["GSI_2_SK"] == "dummy_ml_model_0"
         assert actual["user_id"] == "test_user_id_0"
-        assert actual["suggested_book_sk"] == "1234567890123#dummy_ml_model_0"
+        assert actual["isbn"] == "1234567890123"
+        assert actual["ml_model"] == "dummy_ml_model_0"
         assert actual["interested"] is True
         assert actual["updated_at"] == "2022-04-01T00:00:00+09:00"
 
-        actual = response["Items"][1]
+        actual = self.table.get_item(
+            Key={"PK": "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_1"}
+        ).get("Item")
 
+        assert (
+            actual["PK"]
+            == "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_1"
+        )
+        assert actual["GSI_PK"] == "suggested_book"
+        assert actual["GSI_0_SK"] == "test_user_id_0"
+        assert actual["GSI_1_SK"] == "1234567890123"
+        assert actual["GSI_2_SK"] == "dummy_ml_model_1"
         assert actual["user_id"] == "test_user_id_0"
-        assert actual["suggested_book_sk"] == "1234567890123#dummy_ml_model_1"
+        assert actual["isbn"] == "1234567890123"
+        assert actual["ml_model"] == "dummy_ml_model_1"
         assert actual["interested"] is True
         assert actual["updated_at"] == "2022-04-01T00:00:00+09:00"
 
     def test_ユーザーとisbnが異なるがmlが同じおすすめされた本を追加できること(self):
-        response = self.table.query(
-            KeyConditionExpression=boto3.dynamodb.conditions.Key("user_id").eq(
-                "test_user_id_0"
-            ),
-        )
-        assert len(response["Items"]) == 0
+        actual = self.table.get_item(
+            Key={"PK": "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_0"}
+        ).get("Item")
+
+        assert actual is None
 
         suggested_book_repository = SuggestedBookRepository()
 
@@ -302,27 +361,30 @@ class TestSuggestedBookRepository:
                 "updated_at": "2022-04-01T00:00:00+09:00",
             }
         )
-        response = self.table.query(
-            KeyConditionExpression=boto3.dynamodb.conditions.Key("user_id").eq(
-                "test_user_id_0"
-            ),
+        actual = self.table.get_item(
+            Key={"PK": "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_0"}
+        ).get("Item")
+
+        assert (
+            actual["PK"]
+            == "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_0"
         )
-        assert len(response["Items"]) == 1
-
-        actual = response["Items"][0]
-
+        assert actual["GSI_PK"] == "suggested_book"
+        assert actual["GSI_0_SK"] == "test_user_id_0"
+        assert actual["GSI_1_SK"] == "1234567890123"
+        assert actual["GSI_2_SK"] == "dummy_ml_model_0"
         assert actual["user_id"] == "test_user_id_0"
-        assert actual["suggested_book_sk"] == "1234567890123#dummy_ml_model_0"
+        assert actual["isbn"] == "1234567890123"
+        assert actual["ml_model"] == "dummy_ml_model_0"
         assert actual["interested"] is True
         assert actual["updated_at"] == "2022-04-01T00:00:00+09:00"
 
         # ２件目のテストデータを作成（user_idとisbnが異なる。mlが同じ。）
-        response = self.table.query(
-            KeyConditionExpression=boto3.dynamodb.conditions.Key("user_id").eq(
-                "test_user_id_1"
-            ),
-        )
-        assert len(response["Items"]) == 0
+        actual = self.table.get_item(
+            Key={"PK": "suggested_book#test_user_id_1#9234567890123#dummy_ml_model_0"}
+        ).get("Item")
+
+        assert actual is None
 
         suggested_book_repository.create(
             {
@@ -333,41 +395,48 @@ class TestSuggestedBookRepository:
                 "updated_at": "2022-04-01T00:00:00+09:00",
             }
         )
-        response = self.table.query(
-            KeyConditionExpression=boto3.dynamodb.conditions.Key("user_id").eq(
-                "test_user_id_0"
-            ),
+        actual = self.table.get_item(
+            Key={"PK": "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_0"}
+        ).get("Item")
+
+        assert (
+            actual["PK"]
+            == "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_0"
         )
-        assert len(response["Items"]) == 1
-
-        actual = response["Items"][0]
-
+        assert actual["GSI_PK"] == "suggested_book"
+        assert actual["GSI_0_SK"] == "test_user_id_0"
+        assert actual["GSI_1_SK"] == "1234567890123"
+        assert actual["GSI_2_SK"] == "dummy_ml_model_0"
         assert actual["user_id"] == "test_user_id_0"
-        assert actual["suggested_book_sk"] == "1234567890123#dummy_ml_model_0"
+        assert actual["isbn"] == "1234567890123"
+        assert actual["ml_model"] == "dummy_ml_model_0"
         assert actual["interested"] is True
         assert actual["updated_at"] == "2022-04-01T00:00:00+09:00"
 
-        response = self.table.query(
-            KeyConditionExpression=boto3.dynamodb.conditions.Key("user_id").eq(
-                "test_user_id_1"
-            ),
+        actual = self.table.get_item(
+            Key={"PK": "suggested_book#test_user_id_1#9234567890123#dummy_ml_model_0"}
+        ).get("Item")
+
+        assert (
+            actual["PK"]
+            == "suggested_book#test_user_id_1#9234567890123#dummy_ml_model_0"
         )
-        assert len(response["Items"]) == 1
-
-        actual = response["Items"][0]
-
+        assert actual["GSI_PK"] == "suggested_book"
+        assert actual["GSI_0_SK"] == "test_user_id_1"
+        assert actual["GSI_1_SK"] == "9234567890123"
+        assert actual["GSI_2_SK"] == "dummy_ml_model_0"
         assert actual["user_id"] == "test_user_id_1"
-        assert actual["suggested_book_sk"] == "9234567890123#dummy_ml_model_0"
+        assert actual["isbn"] == "9234567890123"
+        assert actual["ml_model"] == "dummy_ml_model_0"
         assert actual["interested"] is True
         assert actual["updated_at"] == "2022-04-01T00:00:00+09:00"
 
     def test_ユーザーとmlが異なるがisbnが同じおすすめされた本を追加できること(self):
-        response = self.table.query(
-            KeyConditionExpression=boto3.dynamodb.conditions.Key("user_id").eq(
-                "test_user_id_0"
-            ),
-        )
-        assert len(response["Items"]) == 0
+        actual = self.table.get_item(
+            Key={"PK": "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_0"}
+        ).get("Item")
+
+        assert actual is None
 
         suggested_book_repository = SuggestedBookRepository()
 
@@ -381,27 +450,30 @@ class TestSuggestedBookRepository:
                 "updated_at": "2022-04-01T00:00:00+09:00",
             }
         )
-        response = self.table.query(
-            KeyConditionExpression=boto3.dynamodb.conditions.Key("user_id").eq(
-                "test_user_id_0"
-            ),
+        actual = self.table.get_item(
+            Key={"PK": "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_0"}
+        ).get("Item")
+
+        assert (
+            actual["PK"]
+            == "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_0"
         )
-        assert len(response["Items"]) == 1
-
-        actual = response["Items"][0]
-
+        assert actual["GSI_PK"] == "suggested_book"
+        assert actual["GSI_0_SK"] == "test_user_id_0"
+        assert actual["GSI_1_SK"] == "1234567890123"
+        assert actual["GSI_2_SK"] == "dummy_ml_model_0"
         assert actual["user_id"] == "test_user_id_0"
-        assert actual["suggested_book_sk"] == "1234567890123#dummy_ml_model_0"
+        assert actual["isbn"] == "1234567890123"
+        assert actual["ml_model"] == "dummy_ml_model_0"
         assert actual["interested"] is True
         assert actual["updated_at"] == "2022-04-01T00:00:00+09:00"
 
         # ２件目のテストデータを作成（user_idとmlが異なる。isbnが同じ。）
-        response = self.table.query(
-            KeyConditionExpression=boto3.dynamodb.conditions.Key("user_id").eq(
-                "test_user_id_1"
-            ),
-        )
-        assert len(response["Items"]) == 0
+        actual = self.table.get_item(
+            Key={"PK": "suggested_book#test_user_id_1#1234567890123#dummy_ml_model_1"}
+        ).get("Item")
+
+        assert actual is None
 
         suggested_book_repository.create(
             {
@@ -412,41 +484,47 @@ class TestSuggestedBookRepository:
                 "updated_at": "2022-04-01T00:00:00+09:00",
             }
         )
-        response = self.table.query(
-            KeyConditionExpression=boto3.dynamodb.conditions.Key("user_id").eq(
-                "test_user_id_0"
-            ),
+        actual = self.table.get_item(
+            Key={"PK": "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_0"}
+        ).get("Item")
+
+        assert (
+            actual["PK"]
+            == "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_0"
         )
-        assert len(response["Items"]) == 1
-
-        actual = response["Items"][0]
-
+        assert actual["GSI_PK"] == "suggested_book"
+        assert actual["GSI_0_SK"] == "test_user_id_0"
+        assert actual["GSI_1_SK"] == "1234567890123"
+        assert actual["GSI_2_SK"] == "dummy_ml_model_0"
         assert actual["user_id"] == "test_user_id_0"
-        assert actual["suggested_book_sk"] == "1234567890123#dummy_ml_model_0"
+        assert actual["isbn"] == "1234567890123"
+        assert actual["ml_model"] == "dummy_ml_model_0"
         assert actual["interested"] is True
         assert actual["updated_at"] == "2022-04-01T00:00:00+09:00"
 
-        response = self.table.query(
-            KeyConditionExpression=boto3.dynamodb.conditions.Key("user_id").eq(
-                "test_user_id_1"
-            ),
+        actual = self.table.get_item(
+            Key={"PK": "suggested_book#test_user_id_1#1234567890123#dummy_ml_model_1"}
+        ).get("Item")
+
+        assert (
+            actual["PK"]
+            == "suggested_book#test_user_id_1#1234567890123#dummy_ml_model_1"
         )
-        assert len(response["Items"]) == 1
-
-        actual = response["Items"][0]
-
+        assert actual["GSI_PK"] == "suggested_book"
+        assert actual["GSI_0_SK"] == "test_user_id_1"
+        assert actual["GSI_1_SK"] == "1234567890123"
+        assert actual["GSI_2_SK"] == "dummy_ml_model_1"
         assert actual["user_id"] == "test_user_id_1"
-        assert actual["suggested_book_sk"] == "1234567890123#dummy_ml_model_1"
+        assert actual["isbn"] == "1234567890123"
+        assert actual["ml_model"] == "dummy_ml_model_1"
         assert actual["interested"] is True
         assert actual["updated_at"] == "2022-04-01T00:00:00+09:00"
 
     def test_ユーザーとisbnとmlが全て異なるおすすめされた本を追加できること(self):
-        response = self.table.query(
-            KeyConditionExpression=boto3.dynamodb.conditions.Key("user_id").eq(
-                "test_user_id_0"
-            ),
-        )
-        assert len(response["Items"]) == 0
+        actual = self.table.get_item(
+            Key={"PK": "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_0"}
+        ).get("Item")
+        assert actual is None
 
         suggested_book_repository = SuggestedBookRepository()
 
@@ -460,27 +538,29 @@ class TestSuggestedBookRepository:
                 "updated_at": "2022-04-01T00:00:00+09:00",
             }
         )
-        response = self.table.query(
-            KeyConditionExpression=boto3.dynamodb.conditions.Key("user_id").eq(
-                "test_user_id_0"
-            ),
+        actual = self.table.get_item(
+            Key={"PK": "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_0"}
+        ).get("Item")
+
+        assert (
+            actual["PK"]
+            == "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_0"
         )
-        assert len(response["Items"]) == 1
-
-        actual = response["Items"][0]
-
+        assert actual["GSI_PK"] == "suggested_book"
+        assert actual["GSI_0_SK"] == "test_user_id_0"
+        assert actual["GSI_1_SK"] == "1234567890123"
+        assert actual["GSI_2_SK"] == "dummy_ml_model_0"
         assert actual["user_id"] == "test_user_id_0"
-        assert actual["suggested_book_sk"] == "1234567890123#dummy_ml_model_0"
+        assert actual["isbn"] == "1234567890123"
+        assert actual["ml_model"] == "dummy_ml_model_0"
         assert actual["interested"] is True
         assert actual["updated_at"] == "2022-04-01T00:00:00+09:00"
 
         # ２件目のテストデータを作成（user_idとisbnとmlが異なる。）
-        response = self.table.query(
-            KeyConditionExpression=boto3.dynamodb.conditions.Key("user_id").eq(
-                "test_user_id_1"
-            ),
-        )
-        assert len(response["Items"]) == 0
+        actual = self.table.get_item(
+            Key={"PK": "suggested_book#test_user_id_1#9234567890123#dummy_ml_model_1"}
+        ).get("Item")
+        assert actual is None
 
         suggested_book_repository.create(
             {
@@ -491,31 +571,39 @@ class TestSuggestedBookRepository:
                 "updated_at": "2022-04-01T00:00:00+09:00",
             }
         )
-        response = self.table.query(
-            KeyConditionExpression=boto3.dynamodb.conditions.Key("user_id").eq(
-                "test_user_id_0"
-            ),
+        actual = self.table.get_item(
+            Key={"PK": "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_0"}
+        ).get("Item")
+
+        assert (
+            actual["PK"]
+            == "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_0"
         )
-        assert len(response["Items"]) == 1
-
-        actual = response["Items"][0]
-
+        assert actual["GSI_PK"] == "suggested_book"
+        assert actual["GSI_0_SK"] == "test_user_id_0"
+        assert actual["GSI_1_SK"] == "1234567890123"
+        assert actual["GSI_2_SK"] == "dummy_ml_model_0"
         assert actual["user_id"] == "test_user_id_0"
-        assert actual["suggested_book_sk"] == "1234567890123#dummy_ml_model_0"
+        assert actual["isbn"] == "1234567890123"
+        assert actual["ml_model"] == "dummy_ml_model_0"
         assert actual["interested"] is True
         assert actual["updated_at"] == "2022-04-01T00:00:00+09:00"
 
-        response = self.table.query(
-            KeyConditionExpression=boto3.dynamodb.conditions.Key("user_id").eq(
-                "test_user_id_1"
-            ),
+        actual = self.table.get_item(
+            Key={"PK": "suggested_book#test_user_id_1#9234567890123#dummy_ml_model_1"}
+        ).get("Item")
+
+        assert (
+            actual["PK"]
+            == "suggested_book#test_user_id_1#9234567890123#dummy_ml_model_1"
         )
-        assert len(response["Items"]) == 1
-
-        actual = response["Items"][0]
-
+        assert actual["GSI_PK"] == "suggested_book"
+        assert actual["GSI_0_SK"] == "test_user_id_1"
+        assert actual["GSI_1_SK"] == "9234567890123"
+        assert actual["GSI_2_SK"] == "dummy_ml_model_1"
         assert actual["user_id"] == "test_user_id_1"
-        assert actual["suggested_book_sk"] == "9234567890123#dummy_ml_model_1"
+        assert actual["isbn"] == "9234567890123"
+        assert actual["ml_model"] == "dummy_ml_model_1"
         assert actual["interested"] is True
         assert actual["updated_at"] == "2022-04-01T00:00:00+09:00"
 
@@ -532,17 +620,21 @@ class TestSuggestedBookRepository:
                 "updated_at": "2022-04-01T00:00:00+09:00",
             }
         )
-        response = self.table.query(
-            KeyConditionExpression=boto3.dynamodb.conditions.Key("user_id").eq(
-                "test_user_id_0"
-            ),
+        actual = self.table.get_item(
+            Key={"PK": "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_0"}
+        ).get("Item")
+
+        assert (
+            actual["PK"]
+            == "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_0"
         )
-        assert len(response["Items"]) == 1
-
-        actual = response["Items"][0]
-
+        assert actual["GSI_PK"] == "suggested_book"
+        assert actual["GSI_0_SK"] == "test_user_id_0"
+        assert actual["GSI_1_SK"] == "1234567890123"
+        assert actual["GSI_2_SK"] == "dummy_ml_model_0"
         assert actual["user_id"] == "test_user_id_0"
-        assert actual["suggested_book_sk"] == "1234567890123#dummy_ml_model_0"
+        assert actual["isbn"] == "1234567890123"
+        assert actual["ml_model"] == "dummy_ml_model_0"
         assert actual["interested"] is True
         assert actual["updated_at"] == "2022-04-01T00:00:00+09:00"
 
@@ -556,16 +648,20 @@ class TestSuggestedBookRepository:
                 "updated_at": "2022-04-01T10:00:05+09:00",
             }
         )
-        response = self.table.query(
-            KeyConditionExpression=boto3.dynamodb.conditions.Key("user_id").eq(
-                "test_user_id_0"
-            ),
+        actual = self.table.get_item(
+            Key={"PK": "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_0"}
+        ).get("Item")
+
+        assert (
+            actual["PK"]
+            == "suggested_book#test_user_id_0#1234567890123#dummy_ml_model_0"
         )
-        assert len(response["Items"]) == 1
-
-        actual = response["Items"][0]
-
+        assert actual["GSI_PK"] == "suggested_book"
+        assert actual["GSI_0_SK"] == "test_user_id_0"
+        assert actual["GSI_1_SK"] == "1234567890123"
+        assert actual["GSI_2_SK"] == "dummy_ml_model_0"
         assert actual["user_id"] == "test_user_id_0"
-        assert actual["suggested_book_sk"] == "1234567890123#dummy_ml_model_0"
+        assert actual["isbn"] == "1234567890123"
+        assert actual["ml_model"] == "dummy_ml_model_0"
         assert actual["interested"] is False
         assert actual["updated_at"] == "2022-04-01T10:00:05+09:00"

--- a/bee_slack_app/repository/user_action_repository.py
+++ b/bee_slack_app/repository/user_action_repository.py
@@ -1,14 +1,32 @@
-import os
-
 from bee_slack_app.model.user_action import UserAction
-from bee_slack_app.repository.database import get_database_client
+from bee_slack_app.repository import database
+
+GSI_PK_VALUE = "user_action"
+
+
+def _encode_partition_key(*, user_id: str, created_at: str) -> str:
+    return f"user_action#{user_id}#{created_at}"
 
 
 class UserActionRepository:  # pylint: disable=too-few-public-methods
     def __init__(self):
-        self.table = get_database_client().Table(
-            os.environ["DYNAMODB_TABLE"] + "-user-action"
+        self.table = database.get_table()
+
+    def put(self, user_action: UserAction) -> None:
+        partition_key = _encode_partition_key(
+            user_id=user_action["user_id"], created_at=user_action["created_at"]
         )
 
-    def put(self, item: UserAction) -> None:
+        item = {
+            database.PK: partition_key,
+            database.GSI_PK: GSI_PK_VALUE,
+            database.GSI_0_SK: user_action["created_at"],
+            database.GSI_1_SK: user_action["user_id"],
+            "user_id": user_action["user_id"],
+            "created_at": user_action["created_at"],
+            "action_name": user_action["action_name"],
+            "status": user_action["status"],
+            "payload": user_action["payload"],
+        }
+
         self.table.put_item(Item=item)

--- a/bee_slack_app/repository/user_repository.py
+++ b/bee_slack_app/repository/user_repository.py
@@ -1,15 +1,22 @@
 """ユーザー情報の追加・更新・削除を行います
 """
-import os
 from typing import Optional
 
+from boto3.dynamodb.conditions import Key  # type: ignore
+
 from bee_slack_app.model.user import User
-from bee_slack_app.repository.database import get_database_client
+from bee_slack_app.repository import database
+
+GSI_PK_VALUE = "user"
+
+
+def _encode_partition_key(*, user_id: str) -> str:
+    return f"user#{user_id}"
 
 
 class UserRepository:
     def __init__(self):
-        self.table = get_database_client().Table(os.environ["DYNAMODB_TABLE"] + "-user")
+        self.table = database.get_table()
 
     def get(self, user_id: str) -> Optional[User]:
         """
@@ -21,8 +28,8 @@ class UserRepository:
         Returns:
             User: 取得したユーザー情報。未登録の場合は、Noneを返します。
         """
-        response = self.table.get_item(Key={"user_id": user_id})
-        return response.get("Item")
+        partition_key = _encode_partition_key(user_id=user_id)
+        return self.table.get_item(Key={database.PK: partition_key}).get("Item")
 
     def get_all(self) -> list[User]:
         """
@@ -31,21 +38,21 @@ class UserRepository:
         Returns:
             list[User]: 取得した全てユーザー情報のリスト。未登録の場合は、空のリストを返す
         """
-        response = self.table.scan()
-        users = response["Items"]
-
-        # レスポンスに LastEvaluatedKey が含まれなくなるまでループ処理を実行する
-        while "LastEvaluatedKey" in response:
-            response = self.table.scan(ExclusiveStartKey=response["LastEvaluatedKey"])
-            users.extend(response["Items"])
-
-        return users
+        return self.table.query(
+            IndexName=database.GSI_0,
+            KeyConditionExpression=Key(database.GSI_PK).eq(GSI_PK_VALUE),
+        )["Items"]
 
     def create(self, user: User) -> None:
         """
         データを追加および上書きします
         """
+        partition_key = _encode_partition_key(user_id=user["user_id"])
+
         item = {
+            database.PK: partition_key,
+            database.GSI_PK: GSI_PK_VALUE,
+            database.GSI_0_SK: user["updated_at"],
             "user_id": user["user_id"],
             "user_name": user["user_name"],
             "department": user["department"],

--- a/database/seed/bee_table.json
+++ b/database/seed/bee_table.json
@@ -1,0 +1,40 @@
+[
+  {
+    "PK": "review#U03BAUEM5QS#9784873118253",
+    "GSI_PK": "review",
+    "GSI_0_SK": "2022-04-20T16:29:14+09:00",
+    "GSI_1_SK": "U03BAUEM5QS",
+    "GSI_2_SK": "9784873118253",
+    "updated_at": "2022-04-20T16:29:14+09:00",
+    "user_id": "U03BAUEM5QS",
+    "book_title": "仕事ではじめる機械学習",
+    "isbn": "9784873118253",
+    "review_comment": "役に立つ！ by 岡本",
+    "score_for_me": "5",
+    "score_for_others": "5",
+    "book_image_url": "dummy_book_image_url",
+    "book_author": "dummy_book_author",
+    "book_url": "dummy_book_url"
+  },
+  {
+    "PK": "user#U03BAUEM5QS",
+    "GSI_PK": "user",
+    "GSI_0_SK": "2022-05-13T15:08:25+09:00",
+    "job_type": "engineer",
+    "age_range": "40",
+    "department": "its",
+    "updated_at": "2022-05-13T15:08:25+09:00",
+    "user_id": "U03BAUEM5QS",
+    "user_name": "岡本卓也"
+  },
+  {
+    "PK": "book#251753562000",
+    "GSI_PK": "book",
+    "GSI_0_SK": "9784873118253",
+    "title": "仕事ではじめる機械学習",
+    "author": "dummy_author_0",
+    "url": "dummy_url_0",
+    "image_url": "dummy_image_url_0",
+    "description": "dummy_description_0"
+  }
+]

--- a/scripts/migrate_to_one_table.py
+++ b/scripts/migrate_to_one_table.py
@@ -1,0 +1,122 @@
+import boto3  # type: ignore
+
+
+def main() -> None:
+    """
+    テーブルを一つにまとめる
+    """
+
+    dynamodb = boto3.resource("dynamodb")
+
+    stage = "dev"
+
+    new_table_items = []
+
+    book_table = dynamodb.Table(f"bee-{stage}-book")
+
+    for item in book_table.scan()["Items"]:
+        new_table_items.append(
+            {
+                "PK": "book#" + item["isbn"],
+                "GSI_PK": "book",
+                "GSI_0_SK": item["updated_at"],
+                "isbn": item["isbn"],
+                "title": item["title"],
+                "author": item["author"],
+                "url": item["url"],
+                "image_url": item["image_url"],
+                "description": item["description"],
+                "updated_at": item["updated_at"],
+            }
+        )
+
+    user_table = dynamodb.Table(f"bee-{stage}-user")
+
+    for item in user_table.scan()["Items"]:
+        new_table_items.append(
+            {
+                "PK": "user#" + item["user_id"],
+                "GSI_PK": "user",
+                "GSI_0_SK": item["updated_at"],
+                "user_id": item["user_id"],
+                "user_name": item["user_name"],
+                "department": item["department"],
+                "job_type": item["job_type"],
+                "age_range": item["age_range"],
+                "updated_at": item["updated_at"],
+            }
+        )
+
+    review_table = dynamodb.Table(f"bee-{stage}-review")
+
+    for item in review_table.scan()["Items"]:
+        new_table_items.append(
+            {
+                "PK": "review#" + item["user_id"] + "#" + item["isbn"],
+                "GSI_PK": "review",
+                "GSI_0_SK": item["updated_at"],
+                "GSI_1_SK": item["user_id"],
+                "GSI_2_SK": item["isbn"],
+                "user_id": item["user_id"],
+                "book_title": item["book_title"],
+                "isbn": item["isbn"],
+                "score_for_me": item["score_for_me"],
+                "score_for_others": item["score_for_others"],
+                "review_comment": item["review_comment"],
+                "updated_at": item["updated_at"],
+                "book_image_url": item["book_image_url"],
+                "book_author": item["book_author"],
+                "book_url": item["book_url"],
+                "book_description": item["book_description"],
+            }
+        )
+
+    user_action_table = dynamodb.Table(f"bee-{stage}-user-action")
+
+    for item in user_action_table.scan()["Items"]:
+        new_table_items.append(
+            {
+                "PK": "user_action#" + item["user_id"] + "#" + item["created_at"],
+                "GSI_PK": "user_action",
+                "GSI_0_SK": item["created_at"],
+                "GSI_1_SK": item["user_id"],
+                "user_id": item["user_id"],
+                "created_at": item["created_at"],
+                "action_name": item["action_name"],
+                "status": item["status"],
+                "payload": item["payload"],
+            }
+        )
+
+    suggested_book_table = dynamodb.Table(f"bee-{stage}-suggested-book")
+
+    for item in suggested_book_table.scan()["Items"]:
+        new_table_items.append(
+            {
+                "PK": "suggested_book#"
+                + item["user_id"]
+                + "#"
+                + item["isbn"]
+                + "#"
+                + item["ml_model"],
+                "GSI_PK": "suggested_book",
+                "GSI_0_SK": item["updated_at"],
+                "GSI_1_SK": item["isbn"],
+                "GSI_2_SK": item["ml_model"],
+                "user_id": item["user_id"],
+                "isbn": item["isbn"],
+                "ml_model": item["ml_model"],
+                "interested": item["interested"],
+                "updated_at": item["updated_at"],
+            }
+        )
+
+    bee_table = dynamodb.Table(f"bee-{stage}")
+
+    with bee_table.batch_writer() as batch:
+        for item in new_table_items:
+            batch.put_item(Item=item)
+
+
+if __name__ == "__main__":
+    main()

--- a/serverless.yml
+++ b/serverless.yml
@@ -51,15 +51,66 @@ custom:
     seed:
       development:
         sources:
-          - table: ${self:provider.environment.DYNAMODB_TABLE}-review
-            sources: [database/seed/review.json]
-          - table: ${self:provider.environment.DYNAMODB_TABLE}-user
-            sources: [database/seed/user.json]
-          - table: ${self:provider.environment.DYNAMODB_TABLE}-book
-            sources: [database/seed/book.json]
+          - table: ${self:provider.environment.DYNAMODB_TABLE}
+            sources: [database/seed/bee_table.json]
 
 resources: # CloudFormation template syntax from here on.
   Resources:
+    BeeMainTable:
+      Type: AWS::DynamoDB::Table
+      Properties:
+        TableName: ${self:provider.environment.DYNAMODB_TABLE}
+        AttributeDefinitions:
+          - AttributeName: PK
+            AttributeType: S
+          - AttributeName: GSI_PK
+            AttributeType: S
+          - AttributeName: GSI_0_SK
+            AttributeType: S
+          - AttributeName: GSI_1_SK
+            AttributeType: S
+          - AttributeName: GSI_2_SK
+            AttributeType: S
+        KeySchema:
+          - AttributeName: PK
+            KeyType: HASH
+        ProvisionedThroughput:
+          ReadCapacityUnits: 1
+          WriteCapacityUnits: 1
+        GlobalSecondaryIndexes:
+          - IndexName: GSI_0
+            KeySchema:
+              - AttributeName: GSI_PK
+                KeyType: HASH
+              - AttributeName: GSI_0_SK
+                KeyType: RANGE
+            Projection:
+              ProjectionType: "ALL"
+            ProvisionedThroughput:
+              ReadCapacityUnits: 1
+              WriteCapacityUnits: 1
+          - IndexName: GSI_1
+            KeySchema:
+              - AttributeName: GSI_PK
+                KeyType: HASH
+              - AttributeName: GSI_1_SK
+                KeyType: RANGE
+            Projection:
+              ProjectionType: "ALL"
+            ProvisionedThroughput:
+              ReadCapacityUnits: 1
+              WriteCapacityUnits: 1
+          - IndexName: GSI_2
+            KeySchema:
+              - AttributeName: GSI_PK
+                KeyType: HASH
+              - AttributeName: GSI_2_SK
+                KeyType: RANGE
+            Projection:
+              ProjectionType: "ALL"
+            ProvisionedThroughput:
+              ReadCapacityUnits: 1
+              WriteCapacityUnits: 1
     BeeTable:
       Type: AWS::DynamoDB::Table
       Properties:


### PR DESCRIPTION
for #317 

## DBマイグレーションについて

このPRマージ後に、`scripts/migrate_to_one_table.py`でマイグレーションを実施します。
使われなくなったテーブルは、マイグレーション後、1週間程様子見してから削除したいです。

## 動作確認済み事項

- デプロイによるテーブルの追加が成功することを`stage-d`で確認済みです
- マイグレーションが成功することを`dev`のテーブルから`stage-d`へのテーブルへのマイグレーションで確認済みです