### PR TITLE
おすすめの本の情報をデータベースから取得する

### DIFF
--- a/bee_slack_app/repository/book_repository.py
+++ b/bee_slack_app/repository/book_repository.py
@@ -58,7 +58,28 @@ class BookRepository:
 
         self.table.put_item(Item=item)
 
-    def fetch(
+    def fetch(self, *, isbn: str) -> Optional[Book]:
+        """
+        レビューが投稿されている本を取得する
+
+        Args:
+            isbn: ISBN
+        Returns:
+            取得した本
+        """
+        partition_key = _encode_partition_key(isbn=isbn)
+        item = self.table.get_item(Key={database.PK: partition_key}).get("Item")
+
+        if not item:
+            return None
+
+        item["updated_at"] = datetime.timestamp_to_iso_format(
+            datetime.TIMESTAMP_MAX - float(item["updated_at"])
+        )
+
+        return item
+
+    def fetch_all(
         self,
         *,
         limit: Optional[int] = None,

--- a/bee_slack_app/repository/book_repository_test.py
+++ b/bee_slack_app/repository/book_repository_test.py
@@ -93,7 +93,117 @@ class TestBookRepository:
 
         book_repository = BookRepository()
 
-        books = book_repository.fetch()
+        book = book_repository.fetch(isbn="01234")
+
+        assert book["isbn"] == "01234"
+        assert book["title"] == "dummy_title_2"
+        assert book["author"] == "dummy_author_2"
+        assert book["url"] == "dummy_url_2"
+        assert book["image_url"] == "dummy_image_url_2"
+        assert book["description"] == "dummy_description_2"
+        assert book["updated_at"] == "2022-04-03T00:00:00+09:00"
+
+    def test_fetchで本が存在しない場合はNoneを返すこと(self):
+        item = {
+            "PK": "book#12345",
+            "GSI_PK": "book",
+            "GSI_0_SK": "251753562000.0",
+            "isbn": "12345",
+            "updated_at": "251753562000.0",
+            "title": "dummy_title_0",
+            "author": "dummy_author_0",
+            "url": "dummy_url_0",
+            "image_url": "dummy_image_url_0",
+            "description": "dummy_description_0",
+        }
+
+        self.table.put_item(Item=item)
+
+        item = {
+            "PK": "book#67890",
+            "GSI_PK": "book",
+            "GSI_0_SK": "251753475600.0",
+            "isbn": "67890",
+            "updated_at": "251753475600.0",
+            "title": "dummy_title_1",
+            "author": "dummy_author_1",
+            "url": "dummy_url_1",
+            "image_url": "dummy_image_url_1",
+            "description": "dummy_description_1",
+        }
+
+        self.table.put_item(Item=item)
+
+        item = {
+            "PK": "book#01234",
+            "GSI_PK": "book",
+            "GSI_0_SK": "251753389200.0",
+            "isbn": "01234",
+            "updated_at": "251753389200.0",
+            "title": "dummy_title_2",
+            "author": "dummy_author_2",
+            "url": "dummy_url_2",
+            "image_url": "dummy_image_url_2",
+            "description": "dummy_description_2",
+        }
+
+        self.table.put_item(Item=item)
+
+        book_repository = BookRepository()
+
+        book = book_repository.fetch(isbn="isbn_not_exist")
+
+        assert book is None
+
+    def test_fetch_allで本を取得できること(self):
+        item = {
+            "PK": "book#12345",
+            "GSI_PK": "book",
+            "GSI_0_SK": "251753562000.0",
+            "isbn": "12345",
+            "updated_at": "251753562000.0",
+            "title": "dummy_title_0",
+            "author": "dummy_author_0",
+            "url": "dummy_url_0",
+            "image_url": "dummy_image_url_0",
+            "description": "dummy_description_0",
+        }
+
+        self.table.put_item(Item=item)
+
+        item = {
+            "PK": "book#67890",
+            "GSI_PK": "book",
+            "GSI_0_SK": "251753475600.0",
+            "isbn": "67890",
+            "updated_at": "251753475600.0",
+            "title": "dummy_title_1",
+            "author": "dummy_author_1",
+            "url": "dummy_url_1",
+            "image_url": "dummy_image_url_1",
+            "description": "dummy_description_1",
+        }
+
+        self.table.put_item(Item=item)
+
+        item = {
+            "PK": "book#01234",
+            "GSI_PK": "book",
+            "GSI_0_SK": "251753389200.0",
+            "isbn": "01234",
+            "updated_at": "251753389200.0",
+            "title": "dummy_title_2",
+            "author": "dummy_author_2",
+            "url": "dummy_url_2",
+            "image_url": "dummy_image_url_2",
+            "description": "dummy_description_2",
+        }
+
+        self.table.put_item(Item=item)
+
+        book_repository = BookRepository()
+
+        books = book_repository.fetch_all()
 
         books_items = books["items"]
 
@@ -125,7 +235,7 @@ class TestBookRepository:
         assert books_items[2]["description"] == "dummy_description_0"
         assert books_items[2]["updated_at"] == "2022-04-01T00:00:00+09:00"
 
-    def test_複数回に分けて本を取得できること(self):
+    def test_fetch_allで複数回に分けて本を取得できること(self):
         item = {
             "PK": "book#12345",
             "GSI_PK": "book",
@@ -174,7 +284,7 @@ class TestBookRepository:
         book_repository = BookRepository()
 
         # 1回目
-        books = book_repository.fetch(limit=2)
+        books = book_repository.fetch_all(limit=2)
 
         books_items = books["items"]
 
@@ -199,7 +309,7 @@ class TestBookRepository:
         assert books_items[1]["updated_at"] == "2022-04-02T00:00:00+09:00"
 
         # 2回目
-        books = book_repository.fetch(limit=2, start_key=books["last_key"])
+        books = book_repository.fetch_all(limit=2, start_key=books["last_key"])
 
         books_items = books["items"]
 
@@ -213,14 +323,14 @@ class TestBookRepository:
         assert books_items[0]["description"] == "dummy_description_0"
         assert books_items[0]["updated_at"] == "2022-04-01T00:00:00+09:00"
 
-    def test_本が存在しない場合は空配列を返すこと(self):
+    def test_fetch_allで本が存在しない場合は空配列を返すこと(self):
         response = self.table.scan()
 
         assert len(response["Items"]) == 0
 
         book_repository = BookRepository()
 
-        books = book_repository.fetch()
+        books = book_repository.fetch_all()
 
         books_items = books["items"]
         books_last_key = books["last_key"]

--- a/bee_slack_app/service/book.py
+++ b/bee_slack_app/service/book.py
@@ -42,7 +42,7 @@ def get_books(
 
         start_key = keys[-1] if len(keys) > 0 else None
 
-        books = book_repository.fetch(limit=limit, start_key=start_key)
+        books = book_repository.fetch_all(limit=limit, start_key=start_key)
 
         logger.info(books)
 
@@ -92,7 +92,7 @@ def get_books_before(
 
         start_key = None if is_move_to_first else keys[-3]
 
-        books = book_repository.fetch(limit=limit, start_key=start_key)
+        books = book_repository.fetch_all(limit=limit, start_key=start_key)
 
         logger.info(books)
 

--- a/bee_slack_app/service/book_test.py
+++ b/bee_slack_app/service/book_test.py
@@ -6,11 +6,11 @@ from bee_slack_app.service.book import get_books, get_books_before
 
 
 def test_get_booksで本を取得できること_全件取得の場合(mocker):
-    mock_book_repository_fetch = mocker.patch.object(
+    mock_book_repository_fetch_all = mocker.patch.object(
         BookRepository,
-        "fetch",
+        "fetch_all",
     )
-    mock_book_repository_fetch.return_value = {
+    mock_book_repository_fetch_all.return_value = {
         "items": [
             {
                 "isbn": "3456789012346",
@@ -73,11 +73,11 @@ def test_get_booksで本を取得できること_全件取得の場合(mocker):
 
 
 def test_get_booksで本を取得できること_続きのデータなしの場合(mocker):
-    mock_book_repository_fetch = mocker.patch.object(
+    mock_book_repository_fetch_all = mocker.patch.object(
         BookRepository,
-        "fetch",
+        "fetch_all",
     )
-    mock_book_repository_fetch.return_value = {
+    mock_book_repository_fetch_all.return_value = {
         "items": [
             {
                 "isbn": "3456789012346",
@@ -140,11 +140,11 @@ def test_get_booksで本を取得できること_続きのデータなしの場�
 
 
 def test_get_booksで本を取得できること_続きのデータありの場合(mocker):
-    mock_book_repository_fetch = mocker.patch.object(
+    mock_book_repository_fetch_all = mocker.patch.object(
         BookRepository,
-        "fetch",
+        "fetch_all",
     )
-    mock_book_repository_fetch.return_value = {
+    mock_book_repository_fetch_all.return_value = {
         "items": [
             {
                 "isbn": "3456789012346",
@@ -209,11 +209,11 @@ def test_get_booksで本を取得できること_続きのデータありの場�
 def test_get_booksでbook_repositoryの処理でエラーが発生した場合Noneを返すこと(
     mocker,
 ):
-    mock_book_repository_fetch = mocker.patch.object(
+    mock_book_repository_fetch_all = mocker.patch.object(
         BookRepository,
-        "fetch",
+        "fetch_all",
     )
-    mock_book_repository_fetch.side_effect = Exception("dummy exception")
+    mock_book_repository_fetch_all.side_effect = Exception("dummy exception")
 
     books = get_books(limit=3, keys=["dummy_key_0", "dummy_key_1"])
 
@@ -221,11 +221,11 @@ def test_get_booksでbook_repositoryの処理でエラーが発生した場合No
 
 
 def test_get_books_beforeで本を取得できること_0ページへの遷移の場合(mocker):
-    mock_book_repository_fetch = mocker.patch.object(
+    mock_book_repository_fetch_all = mocker.patch.object(
         BookRepository,
-        "fetch",
+        "fetch_all",
     )
-    mock_book_repository_fetch.return_value = {
+    mock_book_repository_fetch_all.return_value = {
         "items": [
             {
                 "isbn": "3456789012346",
@@ -290,11 +290,11 @@ def test_get_books_beforeで本を取得できること_0ページへの遷移�
 
 
 def test_get_books_beforeで本を取得できること_1ページ以降への遷移の場合(mocker):
-    mock_book_repository_fetch = mocker.patch.object(
+    mock_book_repository_fetch_all = mocker.patch.object(
         BookRepository,
-        "fetch",
+        "fetch_all",
     )
-    mock_book_repository_fetch.return_value = {
+    mock_book_repository_fetch_all.return_value = {
         "items": [
             {
                 "isbn": "3456789012346",
@@ -363,11 +363,11 @@ def test_get_books_beforeで本を取得できること_1ページ以降への�
 def test_get_books_beforeでbook_repositoryの処理でエラーが発生した場合Noneを返すこと(
     mocker,
 ):
-    mock_book_repository_fetch = mocker.patch.object(
+    mock_book_repository_fetch_all = mocker.patch.object(
         BookRepository,
-        "fetch",
+        "fetch_all",
     )
-    mock_book_repository_fetch.side_effect = Exception("dummy exception")
+    mock_book_repository_fetch_all.side_effect = Exception("dummy exception")
 
     books = get_books_before(
         limit=3, keys=["dummy_key_0", "dummy_key_1", "dummy_key_2"]

--- a/bee_slack_app/service/recommend.py
+++ b/bee_slack_app/service/recommend.py
@@ -3,12 +3,13 @@ from typing import Optional
 
 from bee_slack_app.model import RecommendBook, SuggestedBook, User
 from bee_slack_app.repository import (
-    GoogleBooksRepository,
+    BookRepository,
     RecommendBookRepository,
     SuggestedBookRepository,
 )
 from bee_slack_app.utils import datetime
 
+book_repository = BookRepository()
 recommend_book_repository = RecommendBookRepository()
 suggested_book_repository = SuggestedBookRepository()
 
@@ -51,7 +52,7 @@ def recommend(user: User) -> list[RecommendBook]:
 
         recommended_books = []
         for ml_model, isbn in recommended_book_dict.items():
-            book = GoogleBooksRepository().search_book_by_isbn(isbn)
+            book = book_repository.fetch(isbn=isbn)
             if book is not None:
                 suggested_book = suggested_book_repository.get(
                     user_id=user["user_id"], isbn=isbn, ml_model=ml_model
@@ -74,11 +75,11 @@ def recommend(user: User) -> list[RecommendBook]:
                 recommended_book: RecommendBook = {
                     "title": book["title"],
                     "isbn": isbn,
-                    "author": ",".join(book["authors"]),
-                    "url": book["google_books_url"],
+                    "author": book["author"],
+                    "url": book["url"],
                     "image_url": book["image_url"],
                     "description": book["description"],
-                    "updated_at": "no_data",  # この関数を呼ぶ側では不要だが、型的に必要なので、暫定対応
+                    "updated_at": book["updated_at"],
                     "interested": interested,
                     "ml_model": ml_model,
                 }

--- a/bee_slack_app/service/recommend_test.py
+++ b/bee_slack_app/service/recommend_test.py
@@ -2,7 +2,7 @@
 # pylint: disable=invalid-name
 
 from bee_slack_app.model import User
-from bee_slack_app.repository.google_books_repository import GoogleBooksRepository
+from bee_slack_app.repository.book_repository import BookRepository
 from bee_slack_app.repository.recommend_book_repository import RecommendBookRepository
 from bee_slack_app.repository.suggested_book_repository import SuggestedBookRepository
 from bee_slack_app.service.recommend import created_at, recommend
@@ -17,19 +17,18 @@ def test_おすすめの本の情報を取得できること(monkeypatch):
         RecommendBookRepository, "fetch", mock_recommend_book_repository_fetch
     )
 
-    def mock_search_book_by_isbn(_, isbn):
+    def mock_book_repository_fetch(_, isbn):
         return {
             "title": "仕事ではじめる機械学習",
             "isbn": isbn,
-            "authors": ["有賀康顕", "中山心太", "西林孝"],
-            "google_books_url": "test_google_books_url",
+            "author": "有賀康顕,中山心太,西林孝",
+            "url": "test_book_url",
             "image_url": "test_image_url",
             "description": "test_description",
+            "updated_at": "2022-04-01T00:00:00+09:00",
         }
 
-    monkeypatch.setattr(
-        GoogleBooksRepository, "search_book_by_isbn", mock_search_book_by_isbn
-    )
+    monkeypatch.setattr(BookRepository, "fetch", mock_book_repository_fetch)
 
     def mock_suggested_book_repository_get(
         _, *, user_id: str, isbn: str, ml_model: str
@@ -62,10 +61,11 @@ def test_おすすめの本の情報を取得できること(monkeypatch):
     assert recommended_books[0]["isbn"] == "1234567890123"
     assert recommended_books[0]["author"] == "有賀康顕,中山心太,西林孝"
     assert recommended_books[0]["image_url"] == "test_image_url"
-    assert recommended_books[0]["url"] == "test_google_books_url"
+    assert recommended_books[0]["url"] == "test_book_url"
     assert recommended_books[0]["description"] == "test_description"
     assert recommended_books[0]["ml_model"] == "ml-a"
     assert recommended_books[0]["interested"] is True
+    assert recommended_books[0]["updated_at"] == "2022-04-01T00:00:00+09:00"
 
 
 def test_おすすめの本が取得できなかったら空のリストを返すこと(monkeypatch):
@@ -76,19 +76,18 @@ def test_おすすめの本が取得できなかったら空のリストを返�
         RecommendBookRepository, "fetch", mock_recommend_book_repository_fetch
     )
 
-    def mock_search_book_by_isbn(_, isbn):
+    def mock_book_repository_fetch(_, isbn):
         return {
             "title": "仕事ではじめる機械学習",
             "isbn": isbn,
-            "authors": ["有賀康顕", "中山心太", "西林孝"],
-            "google_books_url": "test_google_books_url",
+            "author": "有賀康顕,中山心太,西林孝",
+            "url": "test_book_url",
             "image_url": "test_image_url",
             "description": "test_description",
+            "updated_at": "2022-04-01T00:00:00+09:00",
         }
 
-    monkeypatch.setattr(
-        GoogleBooksRepository, "search_book_by_isbn", mock_search_book_by_isbn
-    )
+    monkeypatch.setattr(BookRepository, "fetch", mock_book_repository_fetch)
 
     def mock_suggested_book_repository_get(
         _, *, user_id: str, isbn: str, ml_model: str
@@ -128,12 +127,10 @@ def test_おすすめの本の情報がNoneのケース(monkeypatch):
         RecommendBookRepository, "fetch", mock_recommend_book_repository_fetch
     )
 
-    def mock_search_book_by_isbn(_, __):
+    def mock_book_repository_fetch(_, __):
         return None
 
-    monkeypatch.setattr(
-        GoogleBooksRepository, "search_book_by_isbn", mock_search_book_by_isbn
-    )
+    monkeypatch.setattr(BookRepository, "fetch", mock_book_repository_fetch)
 
     def mock_suggested_book_repository_get(
         _, *, user_id: str, isbn: str, ml_model: str
@@ -172,19 +169,18 @@ def test_おすすめ本が未登録の場合は登録すること(mocker):
     )
     mock_recommend_book_repository_fetch.return_value = {"ml-a": "1234567890123"}
 
-    def mock_search_book_by_isbn(_, isbn):
+    def mock_book_repository_fetch(_, isbn):
         return {
             "title": "仕事ではじめる機械学習",
             "isbn": isbn,
-            "authors": ["有賀康顕", "中山心太", "西林孝"],
-            "google_books_url": "test_google_books_url",
+            "author": "有賀康顕,中山心太,西林孝",
+            "url": "test_book_url",
             "image_url": "test_image_url",
             "description": "test_description",
+            "updated_at": "2022-04-01T00:00:00+09:00",
         }
 
-    mocker.patch.object(
-        GoogleBooksRepository, "search_book_by_isbn", mock_search_book_by_isbn
-    )
+    mocker.patch.object(BookRepository, "fetch", mock_book_repository_fetch)
 
     mock_suggested_book_repository_get = mocker.patch.object(
         SuggestedBookRepository, "get"
@@ -228,19 +224,18 @@ def test_書影が取得できない場合に書影にNone返値に設定され�
         RecommendBookRepository, "fetch", mock_recommend_book_repository_fetch
     )
 
-    def mock_search_book_by_isbn(_, isbn):
+    def mock_book_repository_fetch(_, isbn):
         return {
             "title": "仕事ではじめる機械学習",
             "isbn": isbn,
-            "authors": ["有賀康顕", "中山心太", "西林孝"],
-            "google_books_url": "test_google_books_url",
+            "author": "有賀康顕,中山心太,西林孝",
+            "url": "test_book_url",
             "image_url": None,
             "description": "test_description",
+            "updated_at": "2022-04-01T00:00:00+09:00",
         }
 
-    monkeypatch.setattr(
-        GoogleBooksRepository, "search_book_by_isbn", mock_search_book_by_isbn
-    )
+    monkeypatch.setattr(BookRepository, "fetch", mock_book_repository_fetch)
 
     def mock_suggested_book_repository_get(
         _, *, user_id: str, isbn: str, ml_model: str
@@ -273,10 +268,11 @@ def test_書影が取得できない場合に書影にNone返値に設定され�
     assert recommended_books[0]["isbn"] == "1234567890123"
     assert recommended_books[0]["author"] == "有賀康顕,中山心太,西林孝"
     assert recommended_books[0]["image_url"] is None
-    assert recommended_books[0]["url"] == "test_google_books_url"
+    assert recommended_books[0]["url"] == "test_book_url"
     assert recommended_books[0]["description"] == "test_description"
     assert recommended_books[0]["ml_model"] == "ml-a"
     assert recommended_books[0]["interested"] is True
+    assert recommended_books[0]["updated_at"] == "2022-04-01T00:00:00+09:00"
 
 
 def test_モジュール内で例外が発生した場合は返値は空のリストであること(monkeypatch):
@@ -287,12 +283,10 @@ def test_モジュール内で例外が発生した場合は返値は空のリ�
         RecommendBookRepository, "fetch", mock_recommend_book_repository_fetch
     )
 
-    def mock_search_book_by_isbn(_, __):
+    def mock_book_repository_fetch(_):
         raise Exception("dummy exception")
 
-    monkeypatch.setattr(
-        GoogleBooksRepository, "search_book_by_isbn", mock_search_book_by_isbn
-    )
+    monkeypatch.setattr(BookRepository, "fetch", mock_book_repository_fetch)
 
     def mock_suggested_book_repository_get(
         _, *, user_id: str, isbn: str, ml_model: str
@@ -332,30 +326,30 @@ def test_複数のおすすめの本の情報を取得できること(monkeypatc
         RecommendBookRepository, "fetch", mock_recommend_book_repository_fetch
     )
 
-    def mock_search_book_by_isbn(_, isbn):
+    def mock_book_repository_fetch(_, isbn):
         if isbn == "1234567890123":
             book = {
                 "title": "test_title_1",
                 "isbn": isbn,
-                "authors": ["test_authors_1"],
-                "google_books_url": "test_google_books_url_1",
+                "author": "test_authors_1",
+                "url": "test_book_url_1",
                 "image_url": "test_image_url_1",
                 "description": "test_description_1",
+                "updated_at": "2022-04-01T00:00:00+09:00",
             }
         elif isbn == "9876543221098":
             book = {
                 "title": "test_title_2",
                 "isbn": isbn,
-                "authors": ["test_authors_2"],
-                "google_books_url": "test_google_books_url_2",
+                "author": "test_authors_2",
+                "url": "test_book_url_2",
                 "image_url": "test_image_url_2",
                 "description": "test_description_2",
+                "updated_at": "2022-04-02T00:00:00+09:00",
             }
         return book
 
-    monkeypatch.setattr(
-        GoogleBooksRepository, "search_book_by_isbn", mock_search_book_by_isbn
-    )
+    monkeypatch.setattr(BookRepository, "fetch", mock_book_repository_fetch)
 
     def mock_suggested_book_repository_get(
         _, *, user_id: str, isbn: str, ml_model: str
@@ -396,19 +390,21 @@ def test_複数のおすすめの本の情報を取得できること(monkeypatc
     assert recommended_books[0]["isbn"] == "1234567890123"
     assert recommended_books[0]["author"] == "test_authors_1"
     assert recommended_books[0]["image_url"] == "test_image_url_1"
-    assert recommended_books[0]["url"] == "test_google_books_url_1"
+    assert recommended_books[0]["url"] == "test_book_url_1"
     assert recommended_books[0]["description"] == "test_description_1"
     assert recommended_books[0]["ml_model"] == "ml-a"
     assert recommended_books[0]["interested"] is True
+    assert recommended_books[0]["updated_at"] == "2022-04-01T00:00:00+09:00"
 
     assert recommended_books[1]["title"] == "test_title_2"
     assert recommended_books[1]["isbn"] == "9876543221098"
     assert recommended_books[1]["author"] == "test_authors_2"
     assert recommended_books[1]["image_url"] == "test_image_url_2"
-    assert recommended_books[1]["url"] == "test_google_books_url_2"
+    assert recommended_books[1]["url"] == "test_book_url_2"
     assert recommended_books[1]["description"] == "test_description_2"
     assert recommended_books[1]["ml_model"] == "ml-b"
     assert recommended_books[1]["interested"] is False
+    assert recommended_books[1]["updated_at"] == "2022-04-02T00:00:00+09:00"
 
 
 def test_おすすめ情報の生成時刻を取得できること(monkeypatch):


### PR DESCRIPTION
おすすめ本の情報の取得元を、Google Books APIからデータベースに変更します。
不要な、外部APIへのアクセスを減らしたいです。

Repositoryのisbnから本を検索する処理が遅い問題 https://github.com/esminc/boat-bee/issues/380#issuecomment-1166907952 が解決するかもしれません。