### PR TITLE
不要なインスタンス化を削除

### DIFF
--- a/bee_slack_app/service/recommend.py
+++ b/bee_slack_app/service/recommend.py
@@ -102,7 +102,7 @@ def created_at() -> Optional[str]:
     logger = getLogger(__name__)
 
     try:
-        metadata = RecommendBookRepository().fetch_metadata()
+        metadata = recommend_book_repository.fetch_metadata()
 
         return metadata.get("created_at") if metadata is not None else None
 


### PR DESCRIPTION
from https://github.com/esminc/boat-bee/issues/380#issuecomment-1166907952

RecommendBookRepository自体は、この関数でグローバルにインスタンス化されているので、この箇所で改めてインスタンス化する必要はないです。

おそらく、この修正で「Serviceのfetch_metadataでメタデータを取得する処理」が遅い問題は解決すると思われます。