### PR TITLE
sls packageのjobとそれ以外を分ける

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,7 @@ on:
 jobs:
   check-code:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
     steps:
-      - uses: aws-actions/configure-aws-credentials@v1
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ap-northeast-1
       - uses: actions/setup-python@v3
         with:
           python-version: "3.9.11"
@@ -34,7 +27,36 @@ jobs:
       - run: make lint-check
       - run: make type-check
       - run: make test
+
+  check-sls-package:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ap-northeast-1
+      - uses: actions/setup-python@v3
+        with:
+          python-version: "3.9.11"
+      - uses: actions/setup-node@v2
+      - run: npm install -g serverless@3.12.0
+      - uses: actions/checkout@v2.4.0
+      - run: pip install pipenv
+      - uses: actions/cache@v3.0.1
+        with:
+          path: ~/.local/share/virtualenvs
+          key: ${{ runner.os }}-pipenv-${{ hashFiles('./Pipfile.lock') }}
+      - run: make init
       - run: sls package
+
+  notify-if-failure:
+    runs-on: ubuntu-latest
+    needs: [check-code, check-sls-package]
+    if: failure()
+    steps:
       - name: Notify Action Failure to Slack
         uses: slackapi/slack-github-action@v1.18.0
         with:
@@ -54,11 +76,10 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.PR_MESSAGE_SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-        if: failure()
 
   deploy:
     runs-on: ubuntu-latest
-    needs: check-code
+    needs: [check-code, check-sls-package]
     if: contains(github.event_name, 'push')
     permissions:
       id-token: write


### PR DESCRIPTION
`sls package`でAWSの認証情報を使っていますが、同じjobの`make test`などでも認証情報にアクセスすることができてしまい、好ましくないです。よって、`sls package`だけ別のjobとして実行するようにしたいです。

https://github.com/esminc/boat-bee/pull/378#discussion_r904714916 も参考のこと