### PR TITLE
"Powered by Google"をテキストでの表示にする

### DIFF
--- a/bee_slack_app/view/book_search.py
+++ b/bee_slack_app/view/book_search.py
@@ -1,5 +1,5 @@
 from bee_slack_app.model import SearchedBook
-from bee_slack_app.view.common import google_logo_image
+from bee_slack_app.view.common import google_graphic
 
 
 def book_search_result_modal(
@@ -17,7 +17,7 @@ def book_search_result_modal(
         book_results: 本の検索結果のリスト
     """
     blocks = []
-    blocks.append(google_logo_image())
+    blocks.append(google_graphic())
 
     for book in book_results:
         blocks.extend(_generate_book_block(book))
@@ -116,7 +116,7 @@ def book_search_result_selected_modal(
 
     # Blocksで渡ってくるimageには余計なパラメータが付与されているため一旦削除して付け直す
     new_blocks = [x for x in new_blocks if x["type"] != "image"]
-    new_blocks.insert(0, google_logo_image())
+    new_blocks.insert(0, google_graphic())
 
     return {
         "type": "modal",

--- a/bee_slack_app/view/common.py
+++ b/bee_slack_app/view/common.py
@@ -55,12 +55,14 @@ def book_section(
     }
 
 
-def google_logo_image():
+def google_graphic():
     """
-    「Powered by Google」の画像
+    「Powered by Google」
     """
     return {
-        "type": "image",
-        "image_url": "https://developers.google.com/maps/documentation/images/powered_by_google_on_white.png",
-        "alt_text": "Google Logo",
+        "type": "section",
+        "text": {
+            "type": "mrkdwn",
+            "text": "Powered by Google",
+        },
     }

--- a/bee_slack_app/view/home.py
+++ b/bee_slack_app/view/home.py
@@ -1,7 +1,7 @@
 from typing import Optional, TypedDict
 
 from bee_slack_app.model import Book, RecommendBook
-from bee_slack_app.view.common import book_section, google_logo_image
+from bee_slack_app.view.common import book_section, google_graphic
 
 
 class BooksParam(TypedDict):
@@ -183,7 +183,7 @@ def home(  # pylint: disable=too-many-locals
                 "emoji": True,
             },
         },
-        google_logo_image(),
+        google_graphic(),
     ]
 
     view["blocks"].extend(following_blocks)  # type: ignore

--- a/bee_slack_app/view/post_review.py
+++ b/bee_slack_app/view/post_review.py
@@ -1,6 +1,6 @@
 from bee_slack_app.model import Review
 from bee_slack_app.utils import datetime
-from bee_slack_app.view.common import book_section, google_logo_image
+from bee_slack_app.view.common import book_section, google_graphic
 
 
 def search_book_to_review_modal(*, callback_id: str):
@@ -30,7 +30,7 @@ def search_book_to_review_modal(*, callback_id: str):
                     },
                 },
             },
-            google_logo_image(),
+            google_graphic(),
         ],
     }
 
@@ -51,7 +51,7 @@ def post_review_modal(*, callback_id: str, book_section_to_review):
         "close": {"type": "plain_text", "text": "戻る", "emoji": True},
         "submit": {"type": "plain_text", "text": "送信"},
         "blocks": [
-            google_logo_image(),
+            google_graphic(),
             book_section_to_review,
             {
                 "type": "input",

--- a/bee_slack_app/view/read_review.py
+++ b/bee_slack_app/view/read_review.py
@@ -2,7 +2,7 @@ from typing import TypedDict
 
 from bee_slack_app.model import Review, ReviewPagination
 from bee_slack_app.utils import datetime
-from bee_slack_app.view.common import book_section, google_logo_image
+from bee_slack_app.view.common import book_section, google_graphic
 
 
 class BookOfReview(TypedDict):
@@ -28,7 +28,7 @@ def review_modal(*, callback_id: str, book: BookOfReview, reviews: list[Review])
         "callback_id": callback_id,
         "title": {"type": "plain_text", "text": "本のレビュー"},
         "blocks": [
-            google_logo_image(),
+            google_graphic(),
             book_section(
                 title=book["title"],
                 author=book["author"],
@@ -88,7 +88,7 @@ def review_of_user_modal(
         "callback_id": callback_id,
         "title": {"type": "plain_text", "text": "本のレビュー"},
         "blocks": [
-            google_logo_image(),
+            google_graphic(),
             {"type": "divider"},
         ],
     }


### PR DESCRIPTION
close #398 

今までPowered by Googleのロゴとして https://developers.google.com/maps/documentation/images/powered_by_google_on_white.png を置いていたが、同リソースが削除されてしまった。よって、Powered by Googleをテキストに切り替える。

https://developers.google.com/books/branding に「The "powered by Google" graphic must always be displayed alongside any search modules or results.」とあり、graphicという表現から、テキストでも問題ないのではと解釈した。
実際、Google Books APIを利用している[野田市立図書館](https://www.library-noda.jp/)では、テキストで表示している。

<img width="1140" alt="スクリーンショット 2022-07-25 11 59 42" src="https://user-images.githubusercontent.com/48438462/180688823-b05c9056-0e76-4d02-97ba-98df9fc8637f.png">
