### PR TITLE
テストコードをmypyによる型チェックの対象外とする

### DIFF
--- a/lambda/app/mypy.ini
+++ b/lambda/app/mypy.ini
@@ -6,3 +6,5 @@ warn_unused_ignores = True
 no_implicit_optional = True
 warn_unused_configs = True
 disallow_subclassing_any = True
+
+exclude = (?x)(test.py)


### PR DESCRIPTION
テストコードを型チェックするのは、高コスト & 冗長なので、対象外とする